### PR TITLE
pass carleton's silly cookie-check thing

### DIFF
--- a/source/lib/login.js
+++ b/source/lib/login.js
@@ -44,6 +44,12 @@ export async function performLogin(
     return false
   }
 
+  // we have to fetch the page once so that we get the random cookie that
+  // carleton uses to make sure cookies are enabled.
+  // we don't need to _do_ anything with it, since fetch() handles
+  // re-sending it to the server for us.
+  await fetch(CARLETON_LOGIN, {method: 'GET', credentials: 'include'})
+
   const form = buildFormData({username, password})
   const loginResult = await fetch(CARLETON_LOGIN, {
     method: 'POST',


### PR DESCRIPTION
(I don't actually think it's silly.)

My comment from the code:

```js
// we have to fetch the page once so that we get the random cookie that
// carleton uses to make sure cookies are enabled.
// we don't need to _do_ anything with it, since fetch() handles
// re-sending it to the server for us.
```