### PR TITLE
Fix moment formatting in Reason calendar

### DIFF
--- a/source/views/calendar/calendar-reason.js
+++ b/source/views/calendar/calendar-reason.js
@@ -40,9 +40,9 @@ export class ReasonCalendarView extends React.Component {
   buildCalendarUrl(calendarUrl: string, calendarProps: any, now: moment) {
     let params = {
       // eslint-disable-next-line camelcase
-      start_date: now.clone().format('yyyy-mm-dd'),
+      start_date: now.clone().format('YYYY-MM-DD'),
       // eslint-disable-next-line camelcase
-      end_date: now.clone().add(1, 'month').format('yyyy-mm-dd'),
+      end_date: now.clone().add(1, 'month').format('YYYY-MM-DD'),
       ...(calendarProps || {}),
       format: 'json',
     }


### PR DESCRIPTION
This uppercases the calendar formatting string.

Closes part of #58