### PR TITLE
Remove contact numbers from description preview

### DIFF
--- a/source/views/contacts/contact-detail.js
+++ b/source/views/contacts/contact-detail.js
@@ -6,7 +6,6 @@ import glamorous from 'glamorous-native'
 import {phonecall} from 'react-native-communications'
 import {tracker} from '../../analytics'
 import {Button} from '../components/button'
-import {formatNumber} from './contact-helper'
 import openUrl from '../components/open-url'
 import type {ContactType} from './types'
 
@@ -27,6 +26,11 @@ const styles = StyleSheet.create({
     fontSize: 16,
   },
 })
+
+function formatNumber(phoneNumber: string) {
+  const re = /(\d{3})-?(\d{3})-?(\d{4})/g
+  return phoneNumber.replace(re, '($1) $2-$3')
+}
 
 function promptCall(buttonText: string, phoneNumber: string) {
   Alert.alert(buttonText, formatNumber(phoneNumber), [

--- a/source/views/contacts/contact-helper.js
+++ b/source/views/contacts/contact-helper.js
@@ -1,6 +1,0 @@
-// @flow
-
-export function formatNumber(phoneNumber: string) {
-  const re = /(\d{3})-?(\d{3})-?(\d{4})/g
-  return phoneNumber.replace(re, '($1) $2-$3')
-}

--- a/source/views/contacts/contact-row.js
+++ b/source/views/contacts/contact-row.js
@@ -2,7 +2,6 @@
 
 import React from 'react'
 import type {ContactType} from './types'
-import {formatNumber} from './contact-helper'
 import {ListRow, Detail, Title} from '../components/list'
 import {Column, Row} from '../components/layout'
 
@@ -23,9 +22,6 @@ export class ContactRow extends React.PureComponent {
           <Column flex={1}>
             <Title lines={1}>{contact.title}</Title>
             <Detail lines={1}>
-              {contact.phoneNumber
-                ? formatNumber(contact.phoneNumber) + ' • '
-                : ''}
               {contact.synopsis}
             </Detail>
           </Column>


### PR DESCRIPTION
Followup to #72 

* Adjust rows to only render the non-md description snippet
* Move format number function back into detail view
* Delete helper file

Before | After
--|--
 ![before](https://user-images.githubusercontent.com/5240843/29900585-ee9b6c40-8dc0-11e7-850d-7ffe0e79c7a2.png) | ![after](https://user-images.githubusercontent.com/5240843/29900584-ee97317a-8dc0-11e7-8199-b027512dbe81.png)