### PR TITLE
Test using textinput instead in row cell

### DIFF
--- a/source/views/news/index.js
+++ b/source/views/news/index.js
@@ -16,7 +16,7 @@ export default TabNavigator(
 				<NoonNewsView
 					name="Noon News Bulletin"
 					navigation={navigation}
-					url="https://apps.carleton.edu/campact/nnb/show.php3"
+					url="https://apps.carleton.edu/campact/nnb/show.php3?style=rss"
 				/>
 			),
 			navigationOptions: {

--- a/source/views/news/noon-news-bulletin/list.js
+++ b/source/views/news/noon-news-bulletin/list.js
@@ -9,7 +9,6 @@ import LoadingView from '../../components/loading'
 import * as c from '../../components/colors'
 import groupBy from 'lodash/groupBy'
 import toPairs from 'lodash/toPairs'
-import qs from 'querystring'
 import delay from 'delay'
 import type {TopLevelViewPropsType} from '../../types'
 import type {NewsBulletinType} from './types'
@@ -64,12 +63,7 @@ export class NoonNewsView extends React.PureComponent<Props, State> {
 	}
 
 	fetchData = async () => {
-		let params = {
-			style: 'rss',
-		}
-
-		const noonNewsURL = `${this.props.url}?${qs.stringify(params)}`
-		const bulletins = await fetchXml(noonNewsURL)
+		const bulletins = await fetchXml(this.props.url)
 			.then(resp => resp.rss.channel.item)
 			.catch(err => {
 				reportNetworkProblem(err)

--- a/source/views/news/noon-news-bulletin/list.js
+++ b/source/views/news/noon-news-bulletin/list.js
@@ -14,7 +14,7 @@ import delay from 'delay'
 import type {TopLevelViewPropsType} from '../../types'
 import type {NewsBulletinType} from './types'
 
-const groupbulletins = (bulletins: NewsBulletinType[]) => {
+const groupBulletins = (bulletins: NewsBulletinType[]) => {
 	const grouped = groupBy(bulletins, m => m.category)
 	return toPairs(grouped).map(([key, value]) => ({title: key, data: value}))
 }
@@ -94,7 +94,7 @@ export class NoonNewsView extends React.PureComponent<Props, State> {
 			return <LoadingView />
 		}
 
-		const groupedData = groupbulletins(this.state.bulletins)
+		const groupedData = groupBulletins(this.state.bulletins)
 		return (
 			<SectionList
 				ItemSeparatorComponent={ListSeparator}

--- a/source/views/news/noon-news-bulletin/row.js
+++ b/source/views/news/noon-news-bulletin/row.js
@@ -36,6 +36,7 @@ const styles = StyleSheet.create({
 	title: {
 		color: c.black,
 		fontSize: 17,
+		marginTop: -4,
 		...Platform.select({
 			ios: {
 				fontWeight: '500',

--- a/source/views/news/noon-news-bulletin/row.js
+++ b/source/views/news/noon-news-bulletin/row.js
@@ -1,8 +1,10 @@
 // @flow
 
 import * as React from 'react'
+import {TextInput, Platform, StyleSheet} from 'react-native'
 import type {NewsBulletinType} from './types'
-import {ListRow, Title} from '../../components/list'
+import {ListRow} from '../../components/list'
+import * as c from '../../components/colors'
 import {fastGetTrimmedText} from '../../../lib/html'
 import {AllHtmlEntities} from 'html-entities'
 
@@ -18,10 +20,29 @@ export class NoonNewsRowView extends React.PureComponent<Props> {
 
 		return (
 			<ListRow arrowPosition="none">
-				<Title>
-					{entities.decode(fastGetTrimmedText(bulletin.description))}
-				</Title>
+				<TextInput
+					dataDetectorTypes="all"
+					editable={false}
+					multiline={true}
+					style={styles.title}
+					value={entities.decode(fastGetTrimmedText(bulletin.description))}
+				/>
 			</ListRow>
 		)
 	}
 }
+
+const styles = StyleSheet.create({
+	title: {
+		color: c.black,
+		fontSize: 17,
+		...Platform.select({
+			ios: {
+				fontWeight: '500',
+			},
+			android: {
+				fontWeight: '600',
+			},
+		}),
+	},
+})


### PR DESCRIPTION
Removes `Title` component from Noon News row in favor of `TextInput`

This PR adds:
* native data detector types to iOS (`phoneNumber`, `link`, `address`, and `calendarEvent`)
* peeking actions on said detectors
* select-anywhere-to-copy-and-paste
* drag-and-drop text
* a much more native feel overall to the entire view

We do lose the ability to open links in-app.

&nbsp;  |  &nbsp;
---|---
![image 2018-02-17 11 10 13](https://user-images.githubusercontent.com/5240843/36344174-8628bb88-13d3-11e8-8fe0-6cdd79c53c36.jpg) | ![image 2018-02-17 11 10 11](https://user-images.githubusercontent.com/5240843/36344176-865625fa-13d3-11e8-9f3c-898bcb9cd835.jpg)
![image 2018-02-17 11 10 06](https://user-images.githubusercontent.com/5240843/36344175-863f5e42-13d3-11e8-8131-c6d20485b552.jpg) | ![image 2018-02-17 11 10 18](https://user-images.githubusercontent.com/5240843/36344177-867075e0-13d3-11e8-9e3c-6f3fbe370c33.jpg)