### PR TITLE
Remove call to overlay min on close

### DIFF
--- a/source/views/map-carls/map.js
+++ b/source/views/map-carls/map.js
@@ -156,7 +156,6 @@ export class MapView extends React.Component<Props, State> {
 			visibleMarkers: [],
 			highlighted: [],
 		}))
-		this.setOverlayMin()
 	}
 
 	setOverlayMax = () => this.setState(() => ({overlaySize: 'max'}))

--- a/source/views/map-carls/map.js
+++ b/source/views/map-carls/map.js
@@ -160,7 +160,6 @@ export class MapView extends React.Component<Props, State> {
 
 	setOverlayMax = () => this.setState(() => ({overlaySize: 'max'}))
 	setOverlayMid = () => this.setState(() => ({overlaySize: 'mid'}))
-	setOverlayMin = () => this.setState(() => ({overlaySize: 'min'}))
 
 	onOverlaySizeChange = (size: 'min' | 'mid' | 'max') =>
 		this.setState(() => ({overlaySize: size}))


### PR DESCRIPTION
This tweaks the behavior of the close button on the info overlay. Instead of collapsing the view when hitting (x), it simply brings the other view back. I feel this is more fluid as the user is already able to collapse the view via the drag handle.