### PR TITLE
Link interactable for android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -217,6 +217,7 @@ dependencies {
     implementation project(':react-native-custom-tabs')
     implementation project(':react-native-device-info')
     implementation project(':react-native-google-analytics-bridge')
+    compile project(':react-native-interactable')
     implementation project(':react-native-keychain')
     implementation project(':react-native-linear-gradient')
     implementation project(':react-native-maps')

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -217,7 +217,7 @@ dependencies {
     implementation project(':react-native-custom-tabs')
     implementation project(':react-native-device-info')
     implementation project(':react-native-google-analytics-bridge')
-    compile project(':react-native-interactable')
+    implementation project(':react-native-interactable')
     implementation project(':react-native-keychain')
     implementation project(':react-native-linear-gradient')
     implementation project(':react-native-maps')

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -17,6 +17,9 @@ project(':react-native-device-info').projectDir = new File(rootProject.projectDi
 include ':react-native-google-analytics-bridge'
 project(':react-native-google-analytics-bridge').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-google-analytics-bridge/android')
 
+include ':react-native-interactable'
+project(':react-native-interactable').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-interactable/android')
+
 include ':react-native-keychain'
 project(':react-native-keychain').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-keychain/android')
 


### PR DESCRIPTION
Currently errors within Interactable due to https://github.com/wix/react-native-interactable/issues/185 but this links it correctly.

This didn't link earlier because running `react-native link react-native-interactable` in carls errs out on the android path of `app/src/main/java/com/allaboutolaf` ...