### PR TITLE
Remove separate tab for SUMO view

### DIFF
--- a/source/navigation.js
+++ b/source/navigation.js
@@ -9,7 +9,7 @@ import {ContactsView, ContactsDetailView} from './views/contacts'
 import {DictionaryView, DictionaryDetailView} from './views/dictionary'
 import {HomeView, EditHomeView} from './views/home'
 import {KSTOScheduleView, KRLXScheduleView} from './views/streaming'
-import {SumoTabView, RadioTabView} from './views/streaming/carls-index'
+import {SumoUpcomingView, RadioTabView} from './views/streaming/carls-index'
 import {MenusView} from './views/menus'
 import {FilterView} from './views/components/filter'
 import NewsView from './views/news'
@@ -85,7 +85,7 @@ export const AppNavigator = StackNavigator(
 		IconSettingsView: {screen: IconSettingsView},
 		SettingsView: {screen: SettingsView},
 		SISView: {screen: SISView},
-		SumoTabView: {screen: SumoTabView},
+		SumoUpcomingView: {screen: SumoUpcomingView},
 		RadioTabView: {screen: RadioTabView},
 		KSTOScheduleView: {screen: KSTOScheduleView},
 		KRLXScheduleView: {screen: KRLXScheduleView},

--- a/source/views/streaming/carls-index.js
+++ b/source/views/streaming/carls-index.js
@@ -1,4 +1,4 @@
 // @flow
 
-export {SumoTabView} from './view-sumo'
+export {SumoUpcomingView} from './view-sumo'
 export {RadioTabView} from './view-radio'

--- a/source/views/streaming/view-sumo.js
+++ b/source/views/streaming/view-sumo.js
@@ -4,6 +4,7 @@ import * as React from 'react'
 import {TabNavigator} from '../components/tabbed-view'
 import {TabBarIcon} from '../components/tabbar-icon'
 import {ReasonCalendarView} from '../calendar/calendar-reason'
+import type {TopLevelViewPropsType} from '../types'
 
 export {KSTOScheduleView, KRLXScheduleView} from './radio'
 
@@ -63,4 +64,23 @@ export const SumoTabView = TabNavigator(
 			title: 'SUMO',
 		},
 	},
+)
+
+export const SumoUpcomingView = ({navigation}: TopLevelViewPropsType) => (
+	<ReasonCalendarView
+		calendarUrl="https://apps.carleton.edu/student/orgs/sumo/"
+		eventMapper={event => ({
+			...event,
+			title: event.title.replace(/^SUMO: /, ''),
+			config: {
+				...event.config,
+				endTime: false,
+			},
+		})}
+		navigation={navigation}
+		poweredBy={{
+			title: 'Powered by SUMO',
+			href: 'https://apps.carleton.edu/student/orgs/sumo/',
+		}}
+	/>
 )

--- a/source/views/views.js
+++ b/source/views/views.js
@@ -90,7 +90,7 @@ export const allViews: ViewType[] = [
 	},
 	{
 		type: 'view',
-		view: 'SumoTabView',
+		view: 'SumoUpcomingView',
 		title: 'SUMO',
 		icon: 'video',
 		foreground: 'light',


### PR DESCRIPTION
until such a time as we actually make a nice Movies view

On `master`, there's an "Up Next" tab, and an "Upcoming" tab. I had envisioned Up Next being an instance of the in-progress Weekly Movie view we're working on for AAO, and Upcoming being the movies list, but I don't want to hold up CARLS any longer.

I can switch back to the tab view when weekly movies are finished.