### PR TITLE
Don't store or ask for student credentials

### DIFF
--- a/source/flux/init.js
+++ b/source/flux/init.js
@@ -4,6 +4,7 @@
  */
 
 import {NetInfo} from 'react-native'
+import {checkToken} from '../lib/login'
 import {getTokenValid} from '../lib/storage'
 import {updateOnlineStatus, tick} from './parts/app'
 import {loadHomescreenOrder, loadDisabledViews} from './parts/homescreen'
@@ -19,6 +20,11 @@ import {loadRecentSearches, loadRecentFilters} from './parts/courses'
 
 function tickTock(store) {
 	return setInterval(() => store.dispatch(tick()), 10000)
+}
+
+async function checkTokenValidity(store) {
+	let status = await checkToken()
+	store.dispatch(setTokenValidity(status))
 }
 
 async function loginCredentials(store) {
@@ -60,6 +66,7 @@ export async function init(store: {dispatch: any => any}) {
 
 	// then go do the network stuff in parallel
 	await Promise.all([
+		checkTokenValidity(store),
 		store.dispatch(updateBalances(false)),
 		store.dispatch(getEnabledTools()),
 	])

--- a/source/flux/init.js
+++ b/source/flux/init.js
@@ -4,15 +4,14 @@
  */
 
 import {NetInfo} from 'react-native'
-import {loadLoginCredentials} from '../lib/login'
+import {getTokenValid} from '../lib/storage'
 import {updateOnlineStatus, tick} from './parts/app'
 import {loadHomescreenOrder, loadDisabledViews} from './parts/homescreen'
 import {getEnabledTools} from './parts/help'
 import {loadFavoriteBuildings} from './parts/buildings'
 import {
-	setLoginCredentials,
-	validateLoginCredentials,
 	loadFeedbackStatus,
+	setTokenValidity,
 	loadAcknowledgement,
 } from './parts/settings'
 import {updateBalances} from './parts/balances'
@@ -23,19 +22,8 @@ function tickTock(store) {
 }
 
 async function loginCredentials(store) {
-	const {username, password} = await loadLoginCredentials()
-	if (!username || !password) {
-		return
-	}
-	store.dispatch(setLoginCredentials({username, password}))
-}
-
-async function validateOlafCredentials(store) {
-	const {username, password} = await loadLoginCredentials()
-	if (!username || !password) {
-		return
-	}
-	store.dispatch(validateLoginCredentials({username, password}))
+	const wasValid = await getTokenValid()
+	store.dispatch(setTokenValidity(wasValid))
 }
 
 function netInfoIsConnected(store) {
@@ -72,7 +60,6 @@ export async function init(store: {dispatch: any => any}) {
 
 	// then go do the network stuff in parallel
 	await Promise.all([
-		validateOlafCredentials(store),
 		store.dispatch(updateBalances(false)),
 		store.dispatch(getEnabledTools()),
 	])

--- a/source/lib/financials/balances.js
+++ b/source/lib/financials/balances.js
@@ -51,6 +51,11 @@ export async function getBalances(
 async function fetchBalancesFromServer(): Promise<BalancesOrErrorType> {
 	const result = await fetch(ONECARD_DASHBOARD, {credentials: 'include'})
 	const page = await result.text()
+
+	if (page.contains('Please Sign In')) {
+		return {error: true, value: new Error('not logged in!')}
+	}
+
 	const dom = parseHtml(page)
 
 	return parseBalancesFromDom(dom)

--- a/source/lib/financials/balances.js
+++ b/source/lib/financials/balances.js
@@ -1,6 +1,4 @@
 // @flow
-import {loadLoginCredentials} from '../login'
-import buildFormData from '../formdata'
 import {parseHtml, cssSelect, getTrimmedTextWithSpaces} from '../html'
 import {ONECARD_DASHBOARD} from './urls'
 import type {BalancesShapeType} from './types'
@@ -51,17 +49,7 @@ export async function getBalances(
 }
 
 async function fetchBalancesFromServer(): Promise<BalancesOrErrorType> {
-	const {username, password} = await loadLoginCredentials()
-	if (!username || !password) {
-		return {error: true, value: new Error('not logged in!')}
-	}
-
-	const form = buildFormData({username, password})
-	const result = await fetch(ONECARD_DASHBOARD, {
-		method: 'POST',
-		body: form,
-		credentials: 'include',
-	})
+	const result = await fetch(ONECARD_DASHBOARD, {credentials: 'include'})
 	const page = await result.text()
 	const dom = parseHtml(page)
 

--- a/source/lib/financials/urls.js
+++ b/source/lib/financials/urls.js
@@ -4,5 +4,5 @@ export const FINANCIALS_URL = 'https://www.stolaf.edu/sis/st-financials.cfm'
 export const OLECARD_AUTH_URL =
 	'https://www.stolaf.edu/apps/olecard/checkbalance/authenticate.cfm'
 export const ONECARD_DASHBOARD =
-	'https://apps.carleton.edu/login/?dest_page=https%3A%2F%2Fapps.carleton.edu%2Fcampus%2Fonecard%2Fdashboard%2F&msg_uname=onecard_login_blurb&redir_link_text=the%20OneCard%20dashboard'
+	'https://apps.carleton.edu/campus/onecard/dashboard/'
 export const CARLETON_LOGIN = 'https://apps.carleton.edu/login/'

--- a/source/lib/login.js
+++ b/source/lib/login.js
@@ -67,3 +67,14 @@ export async function performLogin(
 
 	return true
 }
+
+export async function checkToken() {
+	const result = await fetch(CARLETON_LOGIN, {credentials: 'include'})
+	const page = await result.text()
+
+	if (page.contains('Please Sign In')) {
+		return false
+	}
+
+	return true
+}

--- a/source/lib/storage.js
+++ b/source/lib/storage.js
@@ -66,6 +66,19 @@ export function getAcknowledgementStatus(): Promise<boolean> {
 	return getItemAsBoolean(acknowledgementStatusKey)
 }
 
+/// MARK: Credentials
+
+const tokenValidKey = 'credentials:valid'
+export function setTokenValid(valid: boolean) {
+	return setItem(tokenValidKey, valid)
+}
+export function getTokenValid(): Promise<boolean> {
+	return getItemAsBoolean(tokenValidKey)
+}
+export function clearTokenValid(): Promise<any> {
+	return removeItem(tokenValidKey)
+}
+
 /// MARK: Favorite Buildings
 
 const favoriteBuildingsKey = 'buildings:favorited'

--- a/source/navigation.js
+++ b/source/navigation.js
@@ -26,7 +26,7 @@ import TransportationView, {
 	BusMap as BusMapView,
 	OtherModesDetailView,
 } from './views/transportation'
-import SettingsView from './views/settings'
+import SettingsView, {CarletonLoginView} from './views/settings'
 import CreditsView from './views/settings/credits'
 import PrivacyView from './views/settings/privacy'
 import LegalView from './views/settings/legal'
@@ -96,6 +96,7 @@ export const AppNavigator = StackNavigator(
 		OtherModesDetailView: {screen: OtherModesDetailView},
 		BusMapView: {screen: BusMapView},
 		MapView: {screen: MapView},
+		CarletonLoginView: {screen: CarletonLoginView},
 	},
 	{
 		navigationOptions: {

--- a/source/views/home/notice.js
+++ b/source/views/home/notice.js
@@ -6,13 +6,9 @@ import * as c from '../components/colors'
 import sample from 'lodash/sample'
 
 const messages = [
-	'☃️ An Unofficial App Project ☃️',
-	'For students, by students',
-	'By students, for students',
-	'An unofficial St. Olaf app',
-	'For Oles, by Oles',
-	'☃️',
-	'🦁',
+	'☃️🍃 An Unofficial App Project ⛱🍂',
+	'An unofficial Carleton app',
+	'🐧',
 ]
 
 export function UnofficialAppNotice() {

--- a/source/views/settings/components/login-button.js
+++ b/source/views/settings/components/login-button.js
@@ -23,8 +23,8 @@ export function LoginButton({
 			onPress={onPress}
 			title={
 				loading
-					? `Logging in to ${label}…`
-					: loggedIn ? `Sign Out of ${label}` : `Sign In to ${label}`
+					? `Logging in with ${label}…`
+					: loggedIn ? `Sign Out of ${label}` : `Sign In with ${label}`
 			}
 		/>
 	)

--- a/source/views/settings/index.js
+++ b/source/views/settings/index.js
@@ -5,9 +5,11 @@ import {StyleSheet, ScrollView} from 'react-native'
 import {TableView} from 'react-native-tableview-simple'
 import type {TopLevelViewPropsType} from '../types'
 
-import CredentialsLoginSection from './sections/login-credentials'
+import {CarletonLoginSection} from './sections/login-carleton'
 import OddsAndEndsSection from './sections/odds-and-ends'
 import SupportSection from './sections/support'
+
+export {CarletonLoginView} from './login'
 
 const styles = StyleSheet.create({
 	container: {
@@ -23,7 +25,7 @@ export default function SettingsView(props: TopLevelViewPropsType) {
 			keyboardShouldPersistTaps="always"
 		>
 			<TableView>
-				<CredentialsLoginSection />
+				<CarletonLoginSection navigation={props.navigation} />
 
 				<SupportSection navigation={props.navigation} />
 

--- a/source/views/settings/login.js
+++ b/source/views/settings/login.js
@@ -1,0 +1,56 @@
+// @flow
+import React from 'react'
+import {WebView} from 'react-native'
+import {AAO_USER_AGENT} from '../../user-agent'
+
+import {NoticeView} from '../components/notice'
+import type {TopLevelViewPropsType} from '../types'
+
+const LOGIN_URL = 'https://apps.carleton.edu/login/'
+
+type Props = TopLevelViewPropsType & {onLoginComplete: (status: boolean) => any}
+
+type State = {complete: boolean}
+
+export class CarletonLoginView extends React.Component<Props, State> {
+	state = {complete: false}
+	_ref: ?WebView = null
+
+	onMessage = (event: any) => {
+		let status = event.nativeEvent.data
+		if (status.startsWith('You are logged in')) {
+			this.props.navigation.state.params.onLoginComplete(true)
+			this.setState(() => ({complete: true}))
+		}
+	}
+
+	render() {
+		if (this.state.complete) {
+			return (
+				<NoticeView
+					buttonText="Done"
+					onPress={() => this.props.navigation.goBack()}
+					text="You're logged in!"
+				/>
+			)
+		}
+
+		let handler = `
+			var info = document.querySelector(".statusInfo");
+			window.postMessage(info ? info.textContent : "not logged in");
+		`
+
+		return (
+			<WebView
+				ref={handle => (this._ref = handle)}
+				injectedJavaScript={handler}
+				javaScriptEnabled={true}
+				onMessage={this.onMessage}
+				scalesPageToFit={true}
+				source={{uri: LOGIN_URL}}
+				startInLoadingState={true}
+				userAgent={AAO_USER_AGENT}
+			/>
+		)
+	}
+}

--- a/source/views/settings/sections/login-carleton.js
+++ b/source/views/settings/sections/login-carleton.js
@@ -1,0 +1,83 @@
+// @flow
+import React from 'react'
+import {Section} from 'react-native-tableview-simple'
+import type {TopLevelViewPropsType} from '../../types'
+import {LoginButton} from '../components/login-button'
+import {
+	logInViaToken,
+	logOutViaToken,
+	type LoginStateType,
+} from '../../../flux/parts/settings'
+import {type ReduxState} from '../../../flux'
+import {connect} from 'react-redux'
+
+type ReduxStateProps = {
+	loginState: LoginStateType,
+}
+
+type ReduxDispatchProps = {
+	logIn: boolean => any,
+	logOut: () => any,
+}
+
+type Props = TopLevelViewPropsType & ReduxStateProps & ReduxDispatchProps
+
+type State = {
+	loading: boolean,
+}
+
+class TokenLoginSection extends React.Component<Props, State> {
+	state = {
+		loading: false,
+	}
+
+	logIn = () => {
+		this.props.navigation.navigate('CarletonLoginView', {
+			onLoginComplete: this.props.logIn,
+		})
+	}
+
+	logOut = () => {
+		this.props.logOut()
+	}
+
+	render() {
+		let {loginState} = this.props
+		let {loading} = this.state
+
+		const loggedIn = loginState === 'logged-in'
+
+		return (
+			<Section
+				footer="Carleton login allows OneCard access, which enables Schillers and Dining Dollars."
+				header="CARLETON LOGIN"
+			>
+				<LoginButton
+					label="Carleton"
+					loading={loading}
+					loggedIn={loggedIn}
+					onPress={loggedIn ? this.logOut : this.logIn}
+				/>
+			</Section>
+		)
+	}
+}
+
+function mapStateToProps(state: ReduxState): ReduxStateProps {
+	return {
+		loggedIn: state.settings ? state.settings.tokenValid : false,
+		loginState: state.settings ? state.settings.loginState : 'logged-out',
+	}
+}
+
+function mapDispatchToProps(dispatch): ReduxDispatchProps {
+	return {
+		logIn: (s: boolean) => dispatch(logInViaToken(s)),
+		logOut: () => dispatch(logOutViaToken()),
+	}
+}
+
+export const CarletonLoginSection = connect(
+	mapStateToProps,
+	mapDispatchToProps,
+)(TokenLoginSection)

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -267,19 +267,14 @@ function getValueOrNa(value: ?string): string {
 	return value
 }
 
-function FormattedValueCell({
-	indeterminate,
-	label,
-	value,
-	style,
-	formatter,
-}: {
+function FormattedValueCell(props: {
 	indeterminate: boolean,
 	label: string,
 	value: ?string,
 	style?: any,
 	formatter: (?string) => string,
 }) {
+	let {indeterminate, label, value, style, formatter} = props
 	return (
 		<View style={[styles.rectangle, styles.common, styles.balances, style]}>
 			<Text

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -154,7 +154,9 @@ class BalancesView extends React.PureComponent<Props, State> {
 						)}
 					</Section>
 
-					{this.props.loginState !== 'logged-in' || this.props.message ? (
+					{(this.props.loginState !== 'checking' &&
+						this.props.loginState !== 'logged-in') ||
+					this.props.message ? (
 						<Section footer="You'll need to log in again so we can update these numbers.">
 							{this.props.loginState !== 'logged-in' ? (
 								<Cell


### PR DESCRIPTION
Instead, we present a "Log in with Carleton" button, which opens `https://apps.carleton.edu/login`.

&nbsp; | &nbsp;
--- | ---
<img width="432" alt="screen shot 2018-04-22 at 8 21 39 pm" src="https://user-images.githubusercontent.com/464441/39102688-c090c6e2-466b-11e8-8a8d-7dca22295f7f.png"> | <img width="432" alt="screen shot 2018-04-22 at 8 23 31 pm" src="https://user-images.githubusercontent.com/464441/39102689-c288e196-466b-11e8-8cf4-1c8f72a6c86e.png">


Once they've logged in there, we present them with a "back" button, and simply store the cookie like any web browser does.

This means that our session only lasts as long as a browser session does, which … might be less than ideal. I don't know how long the sessions last, currently, but I really don't want to ask for credentials.