### PR TITLE
Disable nextConvoView since it doesn't exist yet

### DIFF
--- a/source/views/convocations/tabs.js
+++ b/source/views/convocations/tabs.js
@@ -8,7 +8,7 @@ import {ArchivedConvocationsView} from './archived'
 
 export default TabNavigator(
 	{
-		NextConvocationView: {screen: NextConvocationView},
+		// NextConvocationView: {screen: NextConvocationView},
 		UpcomingConvocationsView: {screen: UpcomingConvocationsView},
 		ArchivedConvocationsView: {screen: ArchivedConvocationsView},
 	},

--- a/source/views/convocations/tabs.js
+++ b/source/views/convocations/tabs.js
@@ -2,7 +2,7 @@
 
 import {TabNavigator} from '../components/tabbed-view'
 
-import {NextConvocationView} from './next'
+// import {NextConvocationView} from './next'
 import {UpcomingConvocationsView} from './upcoming'
 import {ArchivedConvocationsView} from './archived'
 


### PR DESCRIPTION
This leaves us with just Upcoming and Archived.

(In `master`, NextConvoView was a duplicate of Upcoming.)