### PR TITLE
Revert cookie login

### DIFF
--- a/source/flux/init.js
+++ b/source/flux/init.js
@@ -4,15 +4,15 @@
  */
 
 import {NetInfo} from 'react-native'
-import {checkToken} from '../lib/login'
-import {getTokenValid} from '../lib/storage'
+import {loadLoginCredentials} from '../lib/login'
 import {updateOnlineStatus, tick} from './parts/app'
 import {loadHomescreenOrder, loadDisabledViews} from './parts/homescreen'
 import {getEnabledTools} from './parts/help'
 import {loadFavoriteBuildings} from './parts/buildings'
 import {
+	setLoginCredentials,
+	validateLoginCredentials,
 	loadFeedbackStatus,
-	setTokenValidity,
 	loadAcknowledgement,
 	loadEasterEggStatus,
 } from './parts/settings'
@@ -29,8 +29,19 @@ async function checkTokenValidity(store) {
 }
 
 async function loginCredentials(store) {
-	const wasValid = await getTokenValid()
-	store.dispatch(setTokenValidity(wasValid))
+	const {username, password} = await loadLoginCredentials()
+	if (!username || !password) {
+		return
+	}
+	store.dispatch(setLoginCredentials({username, password}))
+}
+
+async function validateOlafCredentials(store) {
+	const {username, password} = await loadLoginCredentials()
+	if (!username || !password) {
+		return
+	}
+	store.dispatch(validateLoginCredentials({username, password}))
 }
 
 function netInfoIsConnected(store) {
@@ -68,7 +79,7 @@ export async function init(store: {dispatch: any => any}) {
 
 	// then go do the network stuff in parallel
 	await Promise.all([
-		checkTokenValidity(store),
+		validateOlafCredentials(store),
 		store.dispatch(updateBalances(false)),
 		store.dispatch(getEnabledTools()),
 	])

--- a/source/flux/init.js
+++ b/source/flux/init.js
@@ -14,6 +14,7 @@ import {
 	loadFeedbackStatus,
 	setTokenValidity,
 	loadAcknowledgement,
+	loadEasterEggStatus,
 } from './parts/settings'
 import {updateBalances} from './parts/balances'
 import {loadRecentSearches, loadRecentFilters} from './parts/courses'
@@ -54,6 +55,7 @@ export async function init(store: {dispatch: any => any}) {
 		store.dispatch(loadDisabledViews()),
 		store.dispatch(loadFeedbackStatus()),
 		store.dispatch(loadAcknowledgement()),
+		store.dispatch(loadEasterEggStatus()),
 		store.dispatch(loadFavoriteBuildings()),
 		store.dispatch(loadRecentSearches()),
 		store.dispatch(loadRecentFilters()),

--- a/source/flux/init.js
+++ b/source/flux/init.js
@@ -23,11 +23,6 @@ function tickTock(store) {
 	return setInterval(() => store.dispatch(tick()), 10000)
 }
 
-async function checkTokenValidity(store) {
-	let status = await checkToken()
-	store.dispatch(setTokenValidity(status))
-}
-
 async function loginCredentials(store) {
 	const {username, password} = await loadLoginCredentials()
 	if (!username || !password) {

--- a/source/flux/parts/settings.js
+++ b/source/flux/parts/settings.js
@@ -12,6 +12,8 @@ import {
 	getAnalyticsOptOut,
 	getAcknowledgementStatus,
 	setAcknowledgementStatus,
+	getEasterEggStatus,
+	setEasterEggStatus,
 	setTokenValid,
 	clearTokenValid,
 } from '../../lib/storage'
@@ -39,6 +41,7 @@ const CREDENTIALS_VALIDATE_FAILURE = 'settings/CREDENTIALS_VALIDATE_FAILURE'
 const SET_FEEDBACK = 'settings/SET_FEEDBACK'
 const CHANGE_THEME = 'settings/CHANGE_THEME'
 const SIS_ALERT_SEEN = 'settings/SIS_ALERT_SEEN'
+const EASTER_EGG_ENABLED = 'settings/EASTER_EGG_ENABLED'
 const TOKEN_LOGIN = 'settings/TOKEN_LOGIN'
 const TOKEN_LOGOUT = 'settings/TOKEN_LOGOUT'
 
@@ -65,6 +68,16 @@ export async function loadAcknowledgement(): Promise<SisAlertSeenAction> {
 export async function hasSeenAcknowledgement(): Promise<SisAlertSeenAction> {
 	await setAcknowledgementStatus(true)
 	return {type: SIS_ALERT_SEEN, payload: true}
+}
+
+type EasterEggAction = {|type: 'settings/EASTER_EGG_ENABLED', payload: boolean|}
+export async function loadEasterEggStatus(): Promise<EasterEggAction> {
+	return {type: EASTER_EGG_ENABLED, payload: await getEasterEggStatus()}
+}
+
+export async function showEasterEgg(): Promise<EasterEggAction> {
+	await setEasterEggStatus(true)
+	return {type: EASTER_EGG_ENABLED, payload: true}
 }
 
 type SetCredentialsAction = {|
@@ -198,6 +211,7 @@ type Action =
 	| SisAlertSeenAction
 	| CredentialsActions
 	| UpdateBalancesType
+	| EasterEggAction
 
 type CredentialsActions =
 	| LogInActions
@@ -210,6 +224,7 @@ export type State = {
 	+dietaryPreferences: [],
 	+feedbackDisabled: boolean,
 	+unofficiallyAcknowledged: boolean,
+	+easterEggEnabled: boolean,
 
 	+username: string,
 	+password: string,
@@ -225,6 +240,7 @@ const initialState = {
 
 	feedbackDisabled: false,
 	unofficiallyAcknowledged: false,
+	easterEggEnabled: false,
 
 	username: '',
 	password: '',
@@ -285,6 +301,9 @@ export function settings(state: State = initialState, action: Action) {
 				password: action.payload.password,
 			}
 		}
+
+		case EASTER_EGG_ENABLED:
+			return {...state, easterEggEnabled: action.payload}
 
 		case TOKEN_LOGIN: {
 			if (action.error === true) {

--- a/source/lib/financials/balances.js
+++ b/source/lib/financials/balances.js
@@ -1,4 +1,6 @@
 // @flow
+import {loadLoginCredentials} from '../login'
+import buildFormData from '../formdata'
 import {parseHtml, cssSelect, getTrimmedTextWithSpaces} from '../html'
 import {ONECARD_DASHBOARD} from './urls'
 import type {BalancesShapeType} from './types'
@@ -49,7 +51,17 @@ export async function getBalances(
 }
 
 async function fetchBalancesFromServer(): Promise<BalancesOrErrorType> {
-	const result = await fetch(ONECARD_DASHBOARD, {credentials: 'include'})
+	const {username, password} = await loadLoginCredentials()
+	if (!username || !password) {
+		return {error: true, value: new Error('not logged in!')}
+	}
+
+	const form = buildFormData({username, password})
+	const result = await fetch(ONECARD_DASHBOARD, {
+		method: 'POST',
+		body: form,
+		credentials: 'include',
+	})
 	const page = await result.text()
 
 	if (page.includes('Please Sign In')) {

--- a/source/lib/financials/urls.js
+++ b/source/lib/financials/urls.js
@@ -4,5 +4,5 @@ export const FINANCIALS_URL = 'https://www.stolaf.edu/sis/st-financials.cfm'
 export const OLECARD_AUTH_URL =
 	'https://www.stolaf.edu/apps/olecard/checkbalance/authenticate.cfm'
 export const ONECARD_DASHBOARD =
-	'https://apps.carleton.edu/campus/onecard/dashboard/'
+	'https://apps.carleton.edu/login/?dest_page=https%3A%2F%2Fapps.carleton.edu%2Fcampus%2Fonecard%2Fdashboard%2F&msg_uname=onecard_login_blurb&redir_link_text=the%20OneCard%20dashboard'
 export const CARLETON_LOGIN = 'https://apps.carleton.edu/login/'

--- a/source/lib/storage.js
+++ b/source/lib/storage.js
@@ -66,6 +66,14 @@ export function getAcknowledgementStatus(): Promise<boolean> {
 	return getItemAsBoolean(acknowledgementStatusKey)
 }
 
+const easterEggStatusKey = 'settings:easter-egg'
+export function setEasterEggStatus(status: boolean) {
+	return setItem(easterEggStatusKey, status)
+}
+export function getEasterEggStatus(): Promise<boolean> {
+	return getItemAsBoolean(easterEggStatusKey)
+}
+
 /// MARK: Credentials
 
 const tokenValidKey = 'credentials:valid'

--- a/source/navigation.js
+++ b/source/navigation.js
@@ -26,7 +26,7 @@ import TransportationView, {
 	BusMap as BusMapView,
 	OtherModesDetailView,
 } from './views/transportation'
-import SettingsView, {CarletonLoginView} from './views/settings'
+import SettingsView from './views/settings'
 import CreditsView from './views/settings/credits'
 import PrivacyView from './views/settings/privacy'
 import LegalView from './views/settings/legal'
@@ -96,7 +96,6 @@ export const AppNavigator = StackNavigator(
 		OtherModesDetailView: {screen: OtherModesDetailView},
 		BusMapView: {screen: BusMapView},
 		MapView: {screen: MapView},
-		CarletonLoginView: {screen: CarletonLoginView},
 	},
 	{
 		navigationOptions: {

--- a/source/navigation.js
+++ b/source/navigation.js
@@ -13,7 +13,7 @@ import {SumoUpcomingView, RadioTabView} from './views/streaming/carls-index'
 import {MenusView} from './views/menus'
 import {FilterView} from './views/components/filter'
 import NewsView from './views/news'
-import SISView from './views/sis'
+import SISView, {BigBalancesView} from './views/sis'
 import {MapView} from './views/map-carls'
 import {StudentWorkDetailView} from './views/sis/student-work-carls'
 import {
@@ -96,6 +96,7 @@ export const AppNavigator = StackNavigator(
 		OtherModesDetailView: {screen: OtherModesDetailView},
 		BusMapView: {screen: BusMapView},
 		MapView: {screen: MapView},
+		BigBalancesView: {screen: BigBalancesView},
 	},
 	{
 		navigationOptions: {

--- a/source/views/home/home.js
+++ b/source/views/home/home.js
@@ -23,11 +23,26 @@ type ReactProps = TopLevelViewPropsType & {
 type ReduxStateProps = {
 	order: Array<string>,
 	inactiveViews: Array<string>,
+	easterEggEnabled: boolean,
 }
 
 type Props = ReactProps & ReduxStateProps
 
-function HomePage({navigation, order, inactiveViews, views = allViews}: Props) {
+function HomePage(props: Props) {
+	let {navigation, order, inactiveViews, views = allViews} = props
+
+	if (props.easterEggEnabled) {
+		views.unshift({
+			type: 'view',
+			view: 'BigBalancesView',
+			title: 'Balances',
+			icon: 'credit',
+			foreground: 'light',
+			tint: c.goldenrod,
+			gradient: c.yellowToGoldDark,
+		})
+	}
+
 	const sortedViews = sortBy(views, view => order.indexOf(view.view))
 
 	const enabledViews = sortedViews.filter(
@@ -80,12 +95,13 @@ HomePage.navigationOptions = ({navigation}) => {
 
 function mapStateToProps(state: ReduxState): ReduxStateProps {
 	if (!state.homescreen) {
-		return {order: [], inactiveViews: []}
+		return {order: [], inactiveViews: [], easterEggEnabled: false}
 	}
 
 	return {
 		order: state.homescreen.order,
 		inactiveViews: state.homescreen.inactiveViews,
+		easterEggEnabled: state.settings ? state.settings.easterEggEnabled : false,
 	}
 }
 

--- a/source/views/settings/credits.js
+++ b/source/views/settings/credits.js
@@ -6,6 +6,21 @@ import glamorous from 'glamorous-native'
 import {Platform} from 'react-native'
 import {iOSUIKit, material} from 'react-native-typography'
 import {AppLogo} from '../components/logo'
+import {Touchable} from '../components/touchable'
+import {connect} from 'react-redux'
+import {showEasterEgg} from '../../flux/parts/settings'
+import type {TopLevelViewPropsType} from '../types'
+import type {ReduxState} from '../../flux'
+
+type ReduxStateProps = {
+	easterEggEnabled: boolean,
+}
+
+type ReduxDispatchProps = {
+	showEasterEgg: () => any,
+}
+
+type Props = TopLevelViewPropsType & ReduxStateProps & ReduxDispatchProps
 
 const Container = glamorous.scrollView({
 	backgroundColor: c.white,
@@ -49,10 +64,12 @@ const Contributors = glamorous(About)({
 
 const formatPeopleList = arr => arr.map(w => w.replace(' ', ' ')).join(' • ')
 
-export default function CreditsView() {
+function CreditsView(props: Props) {
 	return (
 		<Container contentInsetAdjustmentBehavior="automatic">
-			<AppLogo />
+			<Touchable highlight={false} onPress={props.showEasterEgg}>
+				<AppLogo />
+			</Touchable>
 
 			<Title>{credits.name}</Title>
 			<About>{credits.content}</About>
@@ -65,6 +82,21 @@ export default function CreditsView() {
 		</Container>
 	)
 }
+
 CreditsView.navigationOptions = {
 	title: 'Credits',
 }
+
+function mapState(state: ReduxState): ReduxStateProps {
+	return {
+		easterEggEnabled: state.settings ? state.settings.easterEggEnabled : false,
+	}
+}
+
+function mapDispatch(dispatch): ReduxDispatchProps {
+	return {
+		showEasterEgg: () => dispatch(showEasterEgg()),
+	}
+}
+
+export default connect(mapState, mapDispatch)(CreditsView)

--- a/source/views/settings/index.js
+++ b/source/views/settings/index.js
@@ -15,11 +15,7 @@ type ReduxStateProps = {
 	easterEggEnabled: boolean,
 }
 
-type ReduxDispatchProps = {
-	onShowEasterEgg: (e: boolean) => any,
-}
-
-type Props = TopLevelViewPropsType & ReduxStateProps & ReduxDispatchProps
+type Props = TopLevelViewPropsType & ReduxStateProps
 
 const styles = StyleSheet.create({
 	container: {

--- a/source/views/settings/index.js
+++ b/source/views/settings/index.js
@@ -3,13 +3,23 @@
 import * as React from 'react'
 import {StyleSheet, ScrollView} from 'react-native'
 import {TableView} from 'react-native-tableview-simple'
+import {connect} from 'react-redux'
+import type {ReduxState} from '../../flux'
 import type {TopLevelViewPropsType} from '../types'
 
-import CarletonLoginSection from './sections/login-credentials'
+import CredentialsLoginSection from './sections/login-credentials'
 import OddsAndEndsSection from './sections/odds-and-ends'
 import SupportSection from './sections/support'
 
-//export {CarletonLoginView} from './login'
+type ReduxStateProps = {
+	easterEggEnabled: boolean,
+}
+
+type ReduxDispatchProps = {
+	onShowEasterEgg: (e: boolean) => any,
+}
+
+type Props = TopLevelViewPropsType & ReduxStateProps & ReduxDispatchProps
 
 const styles = StyleSheet.create({
 	container: {
@@ -17,7 +27,7 @@ const styles = StyleSheet.create({
 	},
 })
 
-export default function SettingsView(props: TopLevelViewPropsType) {
+function SettingsView(props: Props) {
 	return (
 		<ScrollView
 			contentContainerStyle={styles.container}
@@ -25,7 +35,7 @@ export default function SettingsView(props: TopLevelViewPropsType) {
 			keyboardShouldPersistTaps="always"
 		>
 			<TableView>
-				<CarletonLoginSection navigation={props.navigation} />
+				{props.easterEggEnabled ? <CredentialsLoginSection /> : null}
 
 				<SupportSection navigation={props.navigation} />
 
@@ -37,3 +47,11 @@ export default function SettingsView(props: TopLevelViewPropsType) {
 SettingsView.navigationOptions = {
 	title: 'Settings',
 }
+
+function mapState(state: ReduxState): ReduxStateProps {
+	return {
+		easterEggEnabled: state.settings ? state.settings.easterEggEnabled : false,
+	}
+}
+
+export default connect(mapState)(SettingsView)

--- a/source/views/settings/index.js
+++ b/source/views/settings/index.js
@@ -5,11 +5,11 @@ import {StyleSheet, ScrollView} from 'react-native'
 import {TableView} from 'react-native-tableview-simple'
 import type {TopLevelViewPropsType} from '../types'
 
-import {CarletonLoginSection} from './sections/login-carleton'
+import CarletonLoginSection from './sections/login-credentials'
 import OddsAndEndsSection from './sections/odds-and-ends'
 import SupportSection from './sections/support'
 
-export {CarletonLoginView} from './login'
+//export {CarletonLoginView} from './login'
 
 const styles = StyleSheet.create({
 	container: {

--- a/source/views/sis/balances.js
+++ b/source/views/sis/balances.js
@@ -200,7 +200,9 @@ function mapDispatch(dispatch): ReduxDispatchProps {
 	}
 }
 
-export default connect(mapState, mapDispatch)(BalancesView)
+const ConnectedBalancesView = connect(mapState, mapDispatch)(BalancesView)
+
+export default ConnectedBalancesView
 
 let cellMargin = 10
 let cellSidePadding = 10
@@ -258,6 +260,13 @@ let styles = StyleSheet.create({
 		fontSize: 16,
 	},
 })
+
+export function BigBalancesView(props: TopLevelViewPropsType) {
+	return <ConnectedBalancesView navigation={props.navigation} />
+}
+BigBalancesView.navigationOptions = {
+	title: 'Balances',
+}
 
 function getValueOrNa(value: ?string): string {
 	// eslint-disable-next-line no-eq-null

--- a/source/views/sis/index.js
+++ b/source/views/sis/index.js
@@ -2,13 +2,13 @@
 
 import {TabNavigator} from '../components/tabbed-view'
 
-import BalancesView from './balances'
+//import BalancesView from './balances'
 import {StudentWorkView} from './student-work-carls'
 import {TheHubView} from './hub'
 
 export default TabNavigator(
 	{
-		BalancesView: {screen: BalancesView},
+		//BalancesView: {screen: BalancesView},
 		TheHubView: {screen: TheHubView},
 		StudentWorkView: {screen: StudentWorkView},
 	},

--- a/source/views/sis/index.js
+++ b/source/views/sis/index.js
@@ -6,6 +6,8 @@ import {TabNavigator} from '../components/tabbed-view'
 import {StudentWorkView} from './student-work-carls'
 import {TheHubView} from './hub'
 
+export {BigBalancesView} from './balances'
+
 export default TabNavigator(
 	{
 		//BalancesView: {screen: BalancesView},


### PR DESCRIPTION
Reverts #165 
Reverts #164 
Includes #146 

---

Cookies aren't working.

I'll just hide the Balances view until the student has tapped Oscar, as Drew originally implemented in #146.

This has been extended to hide the Balances tab entirely, and promotes Balances to a top-level function.