### PR TITLE
No images on Carleton and Carletonian news feeds

### DIFF
--- a/source/views/news/index.js
+++ b/source/views/news/index.js
@@ -31,7 +31,7 @@ export default TabNavigator(
 					mode="rss"
 					name="Carleton"
 					navigation={navigation}
-					thumbnail={newsImages.carleton}
+					thumbnail={false}
 					url="https://apps.carleton.edu/media_relations/feeds/blogs/news"
 				/>
 			),
@@ -48,7 +48,7 @@ export default TabNavigator(
 					mode="rss"
 					name="The Carletonian"
 					navigation={navigation}
-					thumbnail={newsImages.carletonian}
+					thumbnail={false}
 					url="https://apps.carleton.edu/carletonian/feeds/blogs/tonian"
 				/>
 			),

--- a/source/views/news/news-container.js
+++ b/source/views/news/news-container.js
@@ -15,7 +15,7 @@ type Props = TopLevelViewPropsType & {
 	url: string,
 	query?: Object,
 	mode: 'rss' | 'wp-json',
-	thumbnail: number,
+	thumbnail: false | number,
 }
 
 type State = {

--- a/source/views/news/news-list.js
+++ b/source/views/news/news-list.js
@@ -20,7 +20,7 @@ type Props = TopLevelViewPropsType & {
 	onRefresh: () => any,
 	entries: StoryType[],
 	loading: boolean,
-	thumbnail: number,
+	thumbnail: false | number,
 }
 
 export class NewsList extends React.PureComponent<Props> {
@@ -28,7 +28,11 @@ export class NewsList extends React.PureComponent<Props> {
 		return openUrl(url)
 	}
 
-	renderSeparator = () => <ListSeparator spacing={{left: 101}} />
+	renderSeparator = () => (
+		<ListSeparator
+			spacing={{left: this.props.thumbnail === false ? undefined : 101}}
+		/>
+	)
 
 	renderItem = ({item}: {item: StoryType}) => (
 		<NewsRow

--- a/source/views/news/news-row.js
+++ b/source/views/news/news-row.js
@@ -9,7 +9,7 @@ import type {StoryType} from './types'
 type Props = {
 	onPress: string => any,
 	story: StoryType,
-	thumbnail: number,
+	thumbnail: false | number,
 }
 
 export class NewsRow extends React.PureComponent<Props> {
@@ -23,14 +23,19 @@ export class NewsRow extends React.PureComponent<Props> {
 
 	render() {
 		const {story} = this.props
-		const thumb = story.featuredImage
-			? {uri: story.featuredImage}
-			: this.props.thumbnail
+		const thumb =
+			this.props.thumbnail !== false
+				? story.featuredImage
+					? {uri: story.featuredImage}
+					: this.props.thumbnail
+				: null
 
 		return (
 			<ListRow arrowPosition="top" onPress={this._onPress}>
 				<Row alignItems="center">
-					<Image source={thumb} style={styles.image} />
+					{thumb !== null ? (
+						<Image source={thumb} style={styles.image} />
+					) : null}
 					<Column flex={1}>
 						<Title lines={2}>{story.title}</Title>
 						<Detail lines={3}>{story.excerpt}</Detail>


### PR DESCRIPTION
Closes #185 

Since we don't have individual thumbnails on the Carleton and Carletonian sources, I propose that we hide the thumbnail.

| nnb | carleton | carletonian | krlx |
--- | --- | --- | ---
<img width="487" alt="screen shot 2018-04-29 at 8 16 27 pm" src="https://user-images.githubusercontent.com/464441/39413030-4621f94c-4bea-11e8-8c1e-12b4e4920cd1.png"> | <img width="487" alt="screen shot 2018-04-29 at 8 16 28 pm" src="https://user-images.githubusercontent.com/464441/39413031-463ab5c2-4bea-11e8-9bdf-e4aeaa1874a3.png"> | <img width="487" alt="screen shot 2018-04-29 at 8 16 30 pm" src="https://user-images.githubusercontent.com/464441/39413032-465171f4-4bea-11e8-9723-ddbc27b52699.png"> | <img width="487" alt="screen shot 2018-04-29 at 8 16 31 pm" src="https://user-images.githubusercontent.com/464441/39413033-466944f0-4bea-11e8-9dbe-aa396b6bae8f.png">
