### PR TITLE
Set hub nav title to ‘the hub’

### DIFF
--- a/source/views/sis/index.js
+++ b/source/views/sis/index.js
@@ -16,7 +16,7 @@ export default TabNavigator(
 	},
 	{
 		navigationOptions: {
-			title: 'OneCard',
+			title: 'The Hub',
 		},
 	},
 )


### PR DESCRIPTION
Closes #217 

Changes it away from OneCard.