### PR TITLE
Redo map search

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "dom-serializer": "0.1.0",
     "domelementtype": "1.3.0",
     "events": "2.0.0",
+    "fuzzyfind": "2.0.0",
     "get-urls": "7.2.0",
     "glamorous-native": "1.4.0",
     "hamming": "0.0.2",

--- a/source/app.js
+++ b/source/app.js
@@ -4,7 +4,8 @@ import './globalize-fetch'
 import './setup-moment'
 
 import * as React from 'react'
-import {Provider} from 'react-redux'
+import {Provider as ReduxProvider} from 'react-redux'
+import {Provider as UnstatedProvider} from 'unstated'
 import {makeStore, initRedux} from './flux'
 import bugsnag from './bugsnag'
 import {tracker} from './analytics'
@@ -52,9 +53,11 @@ export default class App extends React.Component<Props> {
 
 	render() {
 		return (
-			<Provider store={store}>
-				<AppNavigator onNavigationStateChange={this.trackScreenChanges} />
-			</Provider>
+			<ReduxProvider store={store}>
+				<UnstatedProvider>
+					<AppNavigator onNavigationStateChange={this.trackScreenChanges} />
+				</UnstatedProvider>
+			</ReduxProvider>
 		)
 	}
 }

--- a/source/app.js
+++ b/source/app.js
@@ -5,7 +5,6 @@ import './setup-moment'
 
 import * as React from 'react'
 import {Provider as ReduxProvider} from 'react-redux'
-import {Provider as UnstatedProvider} from 'unstated'
 import {makeStore, initRedux} from './flux'
 import bugsnag from './bugsnag'
 import {tracker} from './analytics'
@@ -54,9 +53,7 @@ export default class App extends React.Component<Props> {
 	render() {
 		return (
 			<ReduxProvider store={store}>
-				<UnstatedProvider>
-					<AppNavigator onNavigationStateChange={this.trackScreenChanges} />
-				</UnstatedProvider>
+				<AppNavigator onNavigationStateChange={this.trackScreenChanges} />
 			</ReduxProvider>
 		)
 	}

--- a/source/navigation.js
+++ b/source/navigation.js
@@ -18,7 +18,7 @@ import {MenusView} from './views/menus'
 import {FilterView} from './views/components/filter'
 import NewsView from './views/news'
 import SISView, {BigBalancesView} from './views/sis'
-import {MapView} from './views/map-carls'
+import {MapView, MapReporterView} from './views/map-carls'
 import {StudentWorkDetailView} from './views/sis/student-work-carls'
 import {
 	BuildingHoursView,
@@ -103,6 +103,7 @@ export const AppNavigator = StackNavigator(
 		OtherModesDetailView: {screen: OtherModesDetailView},
 		BusMapView: {screen: BusMapView},
 		MapView: {screen: MapView},
+		MapReporterView: {screen: MapReporterView},
 		BigBalancesView: {screen: BigBalancesView},
 	},
 	{

--- a/source/views/map-carls/index.js
+++ b/source/views/map-carls/index.js
@@ -1,3 +1,4 @@
 // @flow
 
 export {MapView} from './mapbox'
+export {MapReporterView} from './report'

--- a/source/views/map-carls/info.js
+++ b/source/views/map-carls/info.js
@@ -26,11 +26,18 @@ type Props = {
 	feature: Feature<Building>,
 	onClose: () => any,
 	overlaySize: 'min' | 'mid' | 'max',
+	navigation: any,
 }
 
 export class BuildingInfo extends React.Component<Props> {
 	onClose = () => {
 		this.props.onClose()
+	}
+
+	openReportScreen = () => {
+		this.props.navigation.push('MapReporterView', {
+			building: this.props.feature.properties,
+		})
 	}
 
 	makeBuildingCategory = (building: Building) => {
@@ -165,6 +172,19 @@ export class BuildingInfo extends React.Component<Props> {
 							</Row>
 						</Section>
 					) : null}
+
+					<Section>
+						<Row alignItems="center">
+							<Column flex={1}>
+								<SectionTitle>Found an issue?</SectionTitle>
+								<SectionContent>Let us know!</SectionContent>
+							</Column>
+							<OutlineButton
+								onPress={this.openReportScreen}
+								title="Report an Issue"
+							/>
+						</Row>
+					</Section>
 				</ScrollView>
 			</React.Fragment>
 		)
@@ -194,7 +214,7 @@ const SectionListTitle = glamorous(SectionTitle)({
 const OutlineButton = (props: {
 	title: string,
 	onPress: () => any,
-	disabled: boolean,
+	disabled?: boolean,
 }) => (
 	<Touchable
 		accessibilityTraits="button"

--- a/source/views/map-carls/mapbox.js
+++ b/source/views/map-carls/mapbox.js
@@ -32,7 +32,6 @@ type Props = TopLevelViewPropsType
 type State = {|
 	features: Array<Feature<Building>>,
 	visibleMarkers: Array<string>,
-	highlighted: Array<string>,
 	selectedBuilding: ?Feature<Building>,
 	overlaySize: 'min' | 'mid' | 'max',
 |}
@@ -47,7 +46,6 @@ export class MapView extends React.Component<Props, State> {
 
 	state = {
 		features: [],
-		highlighted: [],
 		visibleMarkers: [],
 		selectedBuilding: null,
 		overlaySize: 'mid',
@@ -64,7 +62,6 @@ export class MapView extends React.Component<Props, State> {
 
 		this.setState(() => ({
 			features: data.features,
-			highlighted: [],
 			visibleMarkers: [],
 		}))
 	}
@@ -133,7 +130,6 @@ export class MapView extends React.Component<Props, State> {
 		this.setState(
 			() => ({
 				visibleMarkers: [id],
-				highlighted: [id],
 				selectedBuilding: match,
 			}),
 			() => {
@@ -169,7 +165,6 @@ export class MapView extends React.Component<Props, State> {
 		this.setState(() => ({
 			selectedBuilding: null,
 			visibleMarkers: [],
-			highlighted: [],
 		}))
 		this.setOverlayMid()
 	}

--- a/source/views/map-carls/mapbox.js
+++ b/source/views/map-carls/mapbox.js
@@ -209,6 +209,7 @@ export class MapView extends React.Component<Props, State> {
 					{this.state.selectedBuilding ? (
 						<BuildingInfo
 							feature={this.state.selectedBuilding}
+							navigation={this.props.navigation}
 							onClose={this.onInfoOverlayClose}
 							overlaySize={this.state.overlaySize}
 						/>

--- a/source/views/map-carls/mapbox.js
+++ b/source/views/map-carls/mapbox.js
@@ -214,13 +214,13 @@ export class MapView extends React.Component<Props, State> {
 						/>
 					) : (
 						<BuildingPicker
+							category={this.state.category}
 							features={features}
 							onCancel={this.onPickerCancel}
+							onCategoryChange={this.handleCategoryChange}
 							onFocus={this.onPickerFocus}
 							onSelect={this.onPickerSelect}
 							overlaySize={this.state.overlaySize}
-							category={this.state.category}
-							onCategoryChange={this.handleCategoryChange}
 						/>
 					)}
 				</Overlay>

--- a/source/views/map-carls/mapbox.js
+++ b/source/views/map-carls/mapbox.js
@@ -12,6 +12,28 @@ import {Overlay} from './overlay'
 import Mapbox from '@mapbox/react-native-mapbox-gl'
 import {MAPBOX_API_KEY} from '../../lib/config'
 import pointInPolygon from '@turf/boolean-point-in-polygon'
+import {Provider, Subscribe, Container} from 'unstated'
+
+type SearchState = {
+	searchQuery: string,
+	category: string,
+}
+
+class SearchContainer extends Container<SearchState> {
+	state = {
+		searchQuery: '',
+		category: 'Buildings',
+	}
+
+	search = (query: string) => {
+		query = query || ''
+		this.setState(() => ({searchQuery: query.toLowerCase()}))
+	}
+
+	pickCategory = (name: string) => {
+		this.setState(() => ({category: name}))
+	}
+}
 
 Mapbox.setAccessToken(MAPBOX_API_KEY)
 
@@ -207,13 +229,21 @@ export class MapView extends React.Component<Props, State> {
 							overlaySize={this.state.overlaySize}
 						/>
 					) : (
-						<BuildingPicker
-							features={features}
-							onCancel={this.onPickerCancel}
-							onFocus={this.onPickerFocus}
-							onSelect={this.onPickerSelect}
-							overlaySize={this.state.overlaySize}
-						/>
+						<Subscribe to={[SearchContainer]}>
+							{bag => (
+								<BuildingPicker
+									features={features}
+									onCancel={this.onPickerCancel}
+									onFocus={this.onPickerFocus}
+									onSelect={this.onPickerSelect}
+									overlaySize={this.state.overlaySize}
+									onSearch={bag.search}
+									searchQuery={bag.state.searchQuery}
+									category={bag.state.category}
+									onCategoryChange={bag.pickCategory}
+								/>
+							)}
+						</Subscribe>
 					)}
 				</Overlay>
 			</View>

--- a/source/views/map-carls/mapbox.js
+++ b/source/views/map-carls/mapbox.js
@@ -12,28 +12,6 @@ import {Overlay} from './overlay'
 import Mapbox from '@mapbox/react-native-mapbox-gl'
 import {MAPBOX_API_KEY} from '../../lib/config'
 import pointInPolygon from '@turf/boolean-point-in-polygon'
-import {Provider, Subscribe, Container} from 'unstated'
-
-type SearchState = {
-	searchQuery: string,
-	category: string,
-}
-
-class SearchContainer extends Container<SearchState> {
-	state = {
-		searchQuery: '',
-		category: 'Buildings',
-	}
-
-	search = (query: string) => {
-		query = query || ''
-		this.setState(() => ({searchQuery: query.toLowerCase()}))
-	}
-
-	pickCategory = (name: string) => {
-		this.setState(() => ({category: name}))
-	}
-}
 
 Mapbox.setAccessToken(MAPBOX_API_KEY)
 
@@ -56,6 +34,8 @@ type State = {|
 	visibleMarkers: Array<string>,
 	selectedBuilding: ?Feature<Building>,
 	overlaySize: 'min' | 'mid' | 'max',
+	searchQuery: string,
+	category: string,
 |}
 
 const originalCenterpoint = [-93.15488752015, 44.460800862266]
@@ -71,6 +51,7 @@ export class MapView extends React.Component<Props, State> {
 		visibleMarkers: [],
 		selectedBuilding: null,
 		overlaySize: 'mid',
+		category: 'Buildings',
 	}
 
 	componentDidMount() {
@@ -199,6 +180,10 @@ export class MapView extends React.Component<Props, State> {
 		this.setState(() => ({overlaySize: size}))
 	}
 
+	handleCategoryChange = (name: string) => {
+		this.setState(() => ({category: name}))
+	}
+
 	render() {
 		let features = this.state.features
 		return (
@@ -229,21 +214,15 @@ export class MapView extends React.Component<Props, State> {
 							overlaySize={this.state.overlaySize}
 						/>
 					) : (
-						<Subscribe to={[SearchContainer]}>
-							{bag => (
-								<BuildingPicker
-									features={features}
-									onCancel={this.onPickerCancel}
-									onFocus={this.onPickerFocus}
-									onSelect={this.onPickerSelect}
-									overlaySize={this.state.overlaySize}
-									onSearch={bag.search}
-									searchQuery={bag.state.searchQuery}
-									category={bag.state.category}
-									onCategoryChange={bag.pickCategory}
-								/>
-							)}
-						</Subscribe>
+						<BuildingPicker
+							features={features}
+							onCancel={this.onPickerCancel}
+							onFocus={this.onPickerFocus}
+							onSelect={this.onPickerSelect}
+							overlaySize={this.state.overlaySize}
+							category={this.state.category}
+							onCategoryChange={this.handleCategoryChange}
+						/>
 					)}
 				</Overlay>
 			</View>

--- a/source/views/map-carls/mapbox.js
+++ b/source/views/map-carls/mapbox.js
@@ -34,7 +34,6 @@ type State = {|
 	visibleMarkers: Array<string>,
 	selectedBuilding: ?Feature<Building>,
 	overlaySize: 'min' | 'mid' | 'max',
-	searchQuery: string,
 	category: string,
 |}
 

--- a/source/views/map-carls/picker.js
+++ b/source/views/map-carls/picker.js
@@ -110,7 +110,7 @@ export class BuildingPicker extends React.Component<Props, State> {
 
 		if (this.state.searchQuery) {
 			matches = fuzzyfind(this.state.searchQuery, matches, {
-				accessor: b => b.properties.name.toLowerCase(),
+				accessor: b => `${b.properties.name.toLowerCase()} ${(b.properties.nickname || '').toLowerCase()}`,
 			})
 		} else {
 			const selectedCategory = this.categoryLookup[this.props.category]

--- a/source/views/map-carls/picker.js
+++ b/source/views/map-carls/picker.js
@@ -4,10 +4,10 @@ import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import * as c from '../components/colors'
 import {SearchBar} from '../components/searchbar'
-import sortBy from 'lodash/sortBy'
 import type {Building, Feature} from './types'
 import {CategoryPicker} from './category-picker'
 import {BuildingList} from './building-list'
+import fuzzyfind from 'fuzzyfind'
 
 type Props = {
 	features: Array<Feature<Building>>,
@@ -106,20 +106,18 @@ export class BuildingPicker extends React.Component<Props, State> {
 			/>
 		) : null
 
-		let matches = this.state.query
-			? this.props.features.filter(b =>
-					b.properties.name.toLowerCase().startsWith(this.state.query),
-			  )
-			: this.props.features
+		let matches = this.props.features
 
-		if (!this.state.query) {
+		if (this.state.query) {
+			matches = fuzzyfind(this.state.query, matches, {
+				accessor: b => b.properties.name.toLowerCase(),
+			})
+		} else {
 			const selectedCategory = this.categoryLookup[this.state.category]
 			matches = matches.filter(b =>
 				b.properties.categories.includes(selectedCategory),
 			)
 		}
-
-		matches = sortBy(matches, (m: Feature<Building>) => m.properties.name)
 
 		return (
 			<React.Fragment>

--- a/source/views/map-carls/picker.js
+++ b/source/views/map-carls/picker.js
@@ -15,13 +15,19 @@ type Props = {
 	overlaySize: 'min' | 'mid' | 'max',
 	onFocus: () => any,
 	onCancel: () => any,
-	onSearch: string => any,
-	searchQuery: string,
 	onCategoryChange: string => any,
 	category: string,
 }
 
-export class BuildingPicker extends React.Component<Props> {
+type State = {
+	searchQuery: string,
+}
+
+export class BuildingPicker extends React.Component<Props, State> {
+	state = {
+		searchQuery: '',
+	}
+
 	componentDidUpdate(prevProps: Props) {
 		const lastSize = prevProps.overlaySize
 		const thisSize = this.props.overlaySize
@@ -38,10 +44,10 @@ export class BuildingPicker extends React.Component<Props> {
 	performSearch = (text: string) => {
 		// Android clear button returns an object
 		if (typeof text !== 'string') {
-			return this.props.onSearch('')
+			return this.handleSearchSubmit('')
 		}
 
-		return this.props.onSearch(text)
+		return this.handleSearchSubmit(text)
 	}
 
 	onSelectBuilding = (id: string) => this.props.onSelect(id)
@@ -61,6 +67,10 @@ export class BuildingPicker extends React.Component<Props> {
 				this.dismissKeyboard()
 			}
 		})
+	}
+
+	handleSearchSubmit = (query: string) => {
+		this.setState(() => ({searchQuery: query.toLowerCase()}))
 	}
 
 	allCategories = ['Buildings', 'Outdoors', 'Parking', 'Athletics']
@@ -88,7 +98,7 @@ export class BuildingPicker extends React.Component<Props> {
 			/>
 		)
 
-		const picker = !this.props.searchQuery ? (
+		const picker = !this.state.searchQuery ? (
 			<CategoryPicker
 				categories={this.allCategories}
 				onChange={this.props.onCategoryChange}
@@ -98,8 +108,8 @@ export class BuildingPicker extends React.Component<Props> {
 
 		let matches = this.props.features
 
-		if (this.props.searchQuery) {
-			matches = fuzzyfind(this.props.searchQuery, matches, {
+		if (this.state.searchQuery) {
+			matches = fuzzyfind(this.state.searchQuery, matches, {
 				accessor: b => b.properties.name.toLowerCase(),
 			})
 		} else {

--- a/source/views/map-carls/picker.js
+++ b/source/views/map-carls/picker.js
@@ -110,7 +110,11 @@ export class BuildingPicker extends React.Component<Props, State> {
 
 		if (this.state.searchQuery) {
 			matches = fuzzyfind(this.state.searchQuery, matches, {
-				accessor: b => `${b.properties.name.toLowerCase()} ${(b.properties.nickname || '').toLowerCase()}`,
+				accessor: b => {
+					let name = b.properties.name.toLowerCase()
+					let nickname = (b.properties.nickname || '').toLowerCase()
+					return `${name} ${nickname}`
+				},
 			})
 		} else {
 			const selectedCategory = this.categoryLookup[this.props.category]

--- a/source/views/map-carls/report/editor.js
+++ b/source/views/map-carls/report/editor.js
@@ -1,0 +1,118 @@
+// @flow
+import * as React from 'react'
+import {ScrollView, View, Text, StyleSheet} from 'react-native'
+import {CellTextField} from '../../components/cells/textfield'
+import {ButtonCell} from '../../components/cells/button'
+import {TableView, Section} from 'react-native-tableview-simple'
+import {submitReport} from './submit'
+import type {Building} from '../types'
+import * as c from '../../components/colors'
+import type {TopLevelViewPropsType} from '../../types'
+
+type Props = TopLevelViewPropsType & {
+	navigation: {state: {params: {item: Building}}},
+}
+
+type State = {
+	name: string,
+	description: string,
+}
+
+export class MapReporterView extends React.PureComponent<Props, State> {
+	static navigationOptions = () => {
+		return {
+			title: 'Suggest an Edit',
+		}
+	}
+
+	static getDerivedStateFromProps(nextProps: Props) {
+		let building = nextProps.navigation.state.params.building
+		return {name: building.name}
+	}
+
+	state = {
+		name: this.props.navigation.state.params.building.name,
+		description: '',
+	}
+
+	submit = () => {
+		submitReport(this.state)
+	}
+
+	onChangeDescription = (desc: string) => {
+		this.setState(() => ({description: desc}))
+	}
+
+	render() {
+		let name = this.props.navigation.state.params.building.name
+		let description = this.state.description
+
+		return (
+			<ScrollView
+				keyboardDismissMode="on-drag"
+				keyboardShouldPersistTaps="always"
+			>
+				<View style={styles.helpWrapper}>
+					<Text style={styles.helpTitle}>Thanks for spotting a problem!</Text>
+					<Text style={styles.helpDescription}>
+						There’s a problem with “{name}”, you say?
+					</Text>
+					<Text style={styles.helpDescription}>
+						If you could tell us what the problems are, we’d greatly appreciate
+						it.
+					</Text>
+				</View>
+
+				<TableView>
+					<Section header="DESCRIPTION">
+						<DefinitionCell
+							onChange={this.onChangeDescription}
+							text={description}
+						/>
+					</Section>
+
+					<Section footer="Thanks for reporting!">
+						<ButtonCell onPress={this.submit} title="Submit Report" />
+					</Section>
+				</TableView>
+			</ScrollView>
+		)
+	}
+}
+
+type TextFieldProps = {text: string, onChange: string => any}
+const DefinitionCell = ({text, onChange = () => {}}: TextFieldProps) => (
+	<CellTextField
+		autoCapitalize="sentences"
+		hideLabel={true}
+		multiline={true}
+		onChangeText={onChange}
+		onSubmitEditing={onChange}
+		placeholder="What’s the problem?"
+		returnKeyType="default"
+		value={text}
+	/>
+)
+
+const styles = StyleSheet.create({
+	helpWrapper: {
+		backgroundColor: c.white,
+		borderTopWidth: StyleSheet.hairlineWidth,
+		borderBottomWidth: StyleSheet.hairlineWidth,
+		borderTopColor: c.iosHeaderTopBorder,
+		borderBottomColor: c.iosHeaderBottomBorder,
+		marginBottom: 10,
+		paddingBottom: 15,
+		paddingTop: 15,
+	},
+	helpTitle: {
+		fontSize: 16,
+		fontWeight: 'bold',
+		paddingHorizontal: 15,
+	},
+	helpDescription: {
+		fontSize: 14,
+		paddingTop: 5,
+		paddingHorizontal: 15,
+	},
+})

--- a/source/views/map-carls/report/index.js
+++ b/source/views/map-carls/report/index.js
@@ -1,0 +1,3 @@
+// @flow
+
+export {MapReporterView} from './editor'

--- a/source/views/map-carls/report/submit.js
+++ b/source/views/map-carls/report/submit.js
@@ -1,0 +1,30 @@
+// @flow
+
+import {sendEmail} from '../../components/send-email'
+import {GH_NEW_ISSUE_URL} from '../../../globals'
+
+export function submitReport({name, description}: {[key: string]: string}) {
+	const body = makeEmailBody({name, description})
+
+	return sendEmail({
+		to: ['rives@stolaf.edu'],
+		subject: `[carls-map] Suggestion for building ${name}`,
+		body,
+	})
+}
+
+function makeEmailBody({name, description}) {
+	return `
+Hi! Thanks for letting us know about a map change.
+
+With regards to the building named "${name}", you said:
+
+> ${description}
+
+Please do not change anything below this line.
+
+------------
+
+Project maintainers: ${GH_NEW_ISSUE_URL}
+`
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2795,6 +2795,10 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
+fuzzyfind@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fuzzyfind/-/fuzzyfind-2.0.0.tgz#e991c8c244099a2f6992cacfc2913347ffd98777"
+
 gauge@~1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-1.2.7.tgz#e9cec5483d3d4ee0ef44b60a7d99e4935e136d93"


### PR DESCRIPTION
Closes #214 
Closes #206 

This reimplements building search with https://www.npmjs.com/package/fuzzyfind, which not only searches but also sorts the list for you.

We now also search the `nickname` field, although there are no nicknames to search yet.

This also fixes the "map category picker resets" bug, by lifting the category state out of the component that gets unmounted when the info box opens. I don't have a better way to accomplish that at this time, unfortunately, which also means that your search _query_ will still be reset.