### PR TITLE
Selectable _and_ tappable links in Markdown bodies

### DIFF
--- a/source/views/components/markdown/link.js
+++ b/source/views/components/markdown/link.js
@@ -23,15 +23,15 @@ type Callback = ({title?: string, href: string}) => any
 
 export class Link extends React.Component<Props> {
 	options: Array<[string, Callback]> = [
-		['Open', ({href}: {href: string}) => openUrl(href)],
+		['Open', ({href}) => openUrl(href)],
 		[
 			'Copy',
-			({title, href}: {href: string, title?: string}) =>
+			({title, href}) =>
 				Clipboard.setString(`${href}${title ? ' ' + title : ''}`),
 		],
 		[
 			'Share…',
-			({href}: {href: string}) =>
+			({href}) =>
 				ActionSheetIOS.showShareActionSheetWithOptions(
 					{url: href},
 					this.onShareFailure,

--- a/source/views/components/markdown/selectable.js
+++ b/source/views/components/markdown/selectable.js
@@ -1,11 +1,15 @@
 // @flow
 
 import * as React from 'react'
-import {TextInput} from 'react-native'
+import {Text, TextInput} from 'react-native'
 
 type Props = {}
 
-export class SelectableText extends React.Component<Props> {
+// TODO: This is disabled until we can figure out how to let Links within the
+// TextInput be tapped. At time of writing (RN 0.55), TextInput captures all
+// input events in order to handle the selection handles, and doesn't let the
+// nested components handle events.
+export class FancySelectableText extends React.Component<Props> {
 	render() {
 		return (
 			<TextInput
@@ -15,5 +19,11 @@ export class SelectableText extends React.Component<Props> {
 				{...this.props}
 			/>
 		)
+	}
+}
+
+export class SelectableText extends React.Component<Props> {
+	render() {
+		return <Text selectable={true} {...this.props} />
 	}
 }


### PR DESCRIPTION
Closes #203 

As discovered in issue #203, when you have a `<Text onPress />` nested within a `<TextInput/>`, the TextInput eats all touch events (I believe to handle selection handles and whatnot).

Until this is fixed, probably at the RN level, which means I should file a bug there, we won't be able to use TextInput to wrap any text that needs to be tappable.