### PR TITLE
Update Career Center location

### DIFF
--- a/data/building-hours/6-5-career-center.yaml
+++ b/data/building-hours/6-5-career-center.yaml
@@ -4,6 +4,7 @@ category: Help and Support
 
 schedule:
   - title: Hours
+    notes: Now located in the Alumni Guest House!
     hours:
       - {days: [Mo, Tu, We, Th, Fr], from: '8:00am', to: '5:00pm'}
 

--- a/data/building-hours/6-5-career-center.yaml
+++ b/data/building-hours/6-5-career-center.yaml
@@ -1,6 +1,6 @@
 name: Career Center
 image: career-center
-category: Sayles-Hill Campus Center
+category: Help and Support
 
 schedule:
   - title: Hours


### PR DESCRIPTION
Closes #261 

I asked the reporter for more information, and they said it has moved to Alumni Guest House, so that's what I've put here.

I also moved this to the category of "Help & Support", because I'm not sure where else to put it? Our current categories are as follows:

1. Food
2. Sayles-Hill Campus Center
3. Radio
4. Museums
5. Libraries
6. Help and Support
7. Gym
8. Student Life & Support
9. Academia
10. Offices