### PR TITLE
Add COVID-19 component

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "react-native-restart": "0.0.6",
     "react-native-safari-view": "2.1.0",
     "react-native-search-bar": "3.4.1",
+    "react-native-searchbar": "1.16.0",
     "react-native-tableview-simple": "0.17.4",
     "react-native-typography": "1.3.0",
     "react-native-vector-icons": "4.6.0",

--- a/source/navigation.js
+++ b/source/navigation.js
@@ -46,6 +46,7 @@ import {
 	ArchivedConvocationDetailView,
 	UpcomingConvocationsDetailView,
 } from './views/convocations'
+import {CovidView, CovidUpdatesView} from './views/covid'
 
 const styles = StyleSheet.create({
 	header: {
@@ -105,6 +106,8 @@ export const AppNavigator = StackNavigator(
 		MapView: {screen: MapView},
 		MapReporterView: {screen: MapReporterView},
 		BigBalancesView: {screen: BigBalancesView},
+		CovidView: {screen: CovidView},
+		CovidUpdatesView: {screen: CovidUpdatesView},
 	},
 	{
 		navigationOptions: {

--- a/source/views/covid/data.js
+++ b/source/views/covid/data.js
@@ -1,0 +1,27 @@
+// @flow
+
+export const buttons = [
+	{
+		title: 'Symptom Tracker',
+		destination: 'https://go.carleton.edu/mySHAC',
+	},
+	{
+		title: 'Student FAQs',
+		destination:
+			'https://www.carleton.edu/covid/frequently-asked-questions/faq-students/',
+	},
+	{
+		title: 'Covid Dashboard',
+		destination: 'https://www.carleton.edu/covid/dashboard/',
+	},
+	{
+		title: 'Sanctions',
+		destination:
+			'https://www.carleton.edu/dean-of-students/student-support/conduct-process/sanction-guidelines-for-violations-of-the-convenant/',
+	},
+	{
+		title: 'Rice County Info',
+		destination:
+			'https://www.co.rice.mn.us/492/Coronavirus-disease-COVID-19-Current-Sit',
+	},
+]

--- a/source/views/covid/index.js
+++ b/source/views/covid/index.js
@@ -1,0 +1,4 @@
+// @flow
+
+export {default as CovidView} from './list'
+export {UpdatesList as CovidUpdatesView} from './updates-list'

--- a/source/views/covid/list.js
+++ b/source/views/covid/list.js
@@ -1,0 +1,61 @@
+// @flow
+
+import * as React from 'react'
+import {StyleSheet, ScrollView} from 'react-native'
+import {UpdatesContainer} from './updates-container'
+import {Card} from '../components/card'
+import {Button} from '../components/button'
+import {openUrl} from '../components/open-url'
+import {buttons} from './data'
+
+import type {TopLevelViewPropsType} from '../types'
+
+type Props = TopLevelViewPropsType
+
+export default class CovidView extends React.Component<Props> {
+	static navigationOptions = {
+		title: 'Covid Response',
+	}
+
+	render() {
+		function handleButtonPress(btn) {
+			return openUrl(btn.destination)
+		}
+
+		return (
+			<ScrollView contentContainerStyle={styles.container}>
+				<Card header="COVID-19 Resources" style={styles.card}>
+					{buttons.map(btn => {
+						const {title} = btn
+						return (
+							<Button
+								key={title}
+								onPress={() => handleButtonPress(btn)}
+								title={title}
+							/>
+						)
+					})}
+				</Card>
+
+				<Card header="Campus Updates on COVID-19" style={styles.card}>
+					<UpdatesContainer
+						navigation={this.props.navigation}
+						title="Campus Updates"
+					/>
+				</Card>
+			</ScrollView>
+		)
+	}
+}
+
+export const styles = StyleSheet.create({
+	container: {
+		paddingTop: 10,
+	},
+	card: {
+		paddingHorizontal: 20,
+		paddingVertical: 15,
+		marginHorizontal: 10,
+		marginBottom: 10,
+	},
+})

--- a/source/views/covid/types.js
+++ b/source/views/covid/types.js
@@ -1,0 +1,107 @@
+// @flow
+
+export type UpdateType = {
+	id: number,
+	date: string,
+	date_gmt: string,
+	guid: GuidType,
+	modified: string,
+	modified_gmt: string,
+	slug: string,
+	status: string,
+	type: string,
+	link: string,
+	title: TitleType,
+	content: ContentType,
+	excerpt: ExcerptType,
+	author: number,
+	featured_media: number,
+	comment_status: string,
+	ping_status: string,
+	sticky: boolean,
+	template: string,
+	format: string,
+	meta: any[],
+	categories: number[],
+	tags: any[],
+	_links: LinksType,
+}
+
+export type GuidType = {
+	rendered: string,
+}
+
+export type TitleType = {
+	rendered: string,
+}
+
+export type ContentType = {
+	rendered: string,
+	protected: boolean,
+}
+
+export type ExcerptType = {
+	rendered: string,
+	protected: boolean,
+}
+
+export type LinksType = {
+	self: SelfItemType[],
+	collection: CollectionItemType[],
+	about: AboutItemType[],
+	author: AuthorItemType[],
+	replies: RepliesItemType[],
+	'version-history': VersionHistoryItemType[],
+	'predecessor-version': PredecessorVersionItemType[],
+	'wp:attachment': WpAttachmentItemType[],
+	'wp:term': WpTermItemType[],
+	curies: CuriesItemType[],
+}
+
+export type SelfItemType = {
+	href: string,
+}
+
+export type CollectionItemType = {
+	href: string,
+}
+
+export type AboutItemType = {
+	href: string,
+}
+
+export type AuthorItemType = {
+	embeddable: boolean,
+	href: string,
+}
+
+export type RepliesItemType = {
+	embeddable: boolean,
+	href: string,
+}
+
+export type VersionHistoryItemType = {
+	count: number,
+	href: string,
+}
+
+export type PredecessorVersionItemType = {
+	id: number,
+	href: string,
+}
+
+export type WpAttachmentItemType = {
+	href: string,
+}
+
+export type WpTermItemType = {
+	taxonomy: string,
+	embeddable: boolean,
+	href: string,
+}
+
+export type CuriesItemType = {
+	name: string,
+	href: string,
+	templated: boolean,
+}

--- a/source/views/covid/types.js
+++ b/source/views/covid/types.js
@@ -7,6 +7,6 @@ export type UpdateType = {
 	datePublished: ?string,
 	excerpt: string,
 	featuredImage: ?string,
-	link: ?string,
+	link: string,
 	title: string,
 }

--- a/source/views/covid/types.js
+++ b/source/views/covid/types.js
@@ -1,107 +1,12 @@
 // @flow
 
 export type UpdateType = {
-	id: number,
-	date: string,
-	date_gmt: string,
-	guid: GuidType,
-	modified: string,
-	modified_gmt: string,
-	slug: string,
-	status: string,
-	type: string,
-	link: string,
-	title: TitleType,
-	content: ContentType,
-	excerpt: ExcerptType,
-	author: number,
-	featured_media: number,
-	comment_status: string,
-	ping_status: string,
-	sticky: boolean,
-	template: string,
-	format: string,
-	meta: any[],
-	categories: number[],
-	tags: any[],
-	_links: LinksType,
-}
-
-export type GuidType = {
-	rendered: string,
-}
-
-export type TitleType = {
-	rendered: string,
-}
-
-export type ContentType = {
-	rendered: string,
-	protected: boolean,
-}
-
-export type ExcerptType = {
-	rendered: string,
-	protected: boolean,
-}
-
-export type LinksType = {
-	self: SelfItemType[],
-	collection: CollectionItemType[],
-	about: AboutItemType[],
-	author: AuthorItemType[],
-	replies: RepliesItemType[],
-	'version-history': VersionHistoryItemType[],
-	'predecessor-version': PredecessorVersionItemType[],
-	'wp:attachment': WpAttachmentItemType[],
-	'wp:term': WpTermItemType[],
-	curies: CuriesItemType[],
-}
-
-export type SelfItemType = {
-	href: string,
-}
-
-export type CollectionItemType = {
-	href: string,
-}
-
-export type AboutItemType = {
-	href: string,
-}
-
-export type AuthorItemType = {
-	embeddable: boolean,
-	href: string,
-}
-
-export type RepliesItemType = {
-	embeddable: boolean,
-	href: string,
-}
-
-export type VersionHistoryItemType = {
-	count: number,
-	href: string,
-}
-
-export type PredecessorVersionItemType = {
-	id: number,
-	href: string,
-}
-
-export type WpAttachmentItemType = {
-	href: string,
-}
-
-export type WpTermItemType = {
-	taxonomy: string,
-	embeddable: boolean,
-	href: string,
-}
-
-export type CuriesItemType = {
-	name: string,
-	href: string,
-	templated: boolean,
+	authors: string[],
+	categories: string[],
+	content: string,
+	datePublished: ?string,
+	excerpt: string,
+	featuredImage: ?string,
+	link: ?string,
+	title: string,
 }

--- a/source/views/covid/updates-container.js
+++ b/source/views/covid/updates-container.js
@@ -1,0 +1,93 @@
+// @flow
+import * as React from 'react'
+import delay from 'delay'
+import LoadingView from '../components/loading'
+import {NoticeView} from '../components/notice'
+import {reportNetworkProblem} from '../../lib/report-network-problem'
+import {UpdatesList} from './updates-list'
+import {ButtonCell} from '../components/cells/button'
+
+import type {TopLevelViewPropsType} from '../types'
+import type {UpdateType} from './types'
+
+type Props = TopLevelViewPropsType & {
+	title: string,
+}
+
+type State = {
+	updates: UpdateType[],
+	loading: boolean,
+	refreshing: boolean,
+	error: ?Error,
+}
+export class UpdatesContainer extends React.PureComponent<Props, State> {
+	state = {
+		updates: [],
+		loading: true,
+		error: null,
+		refreshing: false,
+	}
+
+	componentDidMount() {
+		this.fetchData().then(() => {
+			this.setState(() => ({loading: false}))
+		})
+	}
+
+	fetchData = async () => {
+		try {
+			let url = 'https://www.carleton.edu/covid/wp-json/wp/v2/posts'
+			let updates: UpdateType[] = await fetchJson(url)
+			this.setState(() => ({updates}))
+		} catch (error) {
+			reportNetworkProblem(error)
+			this.setState(() => ({error}))
+		}
+	}
+
+	refresh = async (): any => {
+		let start = Date.now()
+		this.setState(() => ({refreshing: true}))
+
+		await this.fetchData()
+
+		// wait 0.5 seconds – if we let it go at normal speed, it feels broken.
+		let elapsed = Date.now() - start
+		if (elapsed < 500) {
+			await delay(500 - elapsed)
+		}
+		this.setState(() => ({refreshing: false}))
+	}
+
+	onPress = () => {
+		this.props.navigation.push('CovidUpdatesView', {
+			updates: this.state.updates,
+			showAll: true,
+		})
+	}
+
+	render() {
+		if (this.state.error) {
+			return <NoticeView text={`Error: ${this.state.error.message}`} />
+		}
+
+		if (this.state.loading) {
+			return <LoadingView />
+		}
+
+		return (
+			<React.Fragment>
+				<UpdatesList
+					loading={this.state.refreshing}
+					name={this.props.title}
+					navigation={this.props.navigation}
+					onRefresh={this.refresh}
+					showAll={false}
+					updates={this.state.updates}
+				/>
+
+				<ButtonCell onPress={this.onPress} title="See all updates…" />
+			</React.Fragment>
+		)
+	}
+}

--- a/source/views/covid/updates-container.js
+++ b/source/views/covid/updates-container.js
@@ -36,7 +36,7 @@ export class UpdatesContainer extends React.PureComponent<Props, State> {
 
 	fetchData = async () => {
 		try {
-			let url = 'https://www.carleton.edu/covid/wp-json/wp/v2/posts'
+			let url = 'https://carleton.api.frogpond.tech/v1/news/named/covid'
 			let updates: UpdateType[] = await fetchJson(url)
 			this.setState(() => ({updates}))
 		} catch (error) {

--- a/source/views/covid/updates-container.js
+++ b/source/views/covid/updates-container.js
@@ -5,7 +5,6 @@ import LoadingView from '../components/loading'
 import {NoticeView} from '../components/notice'
 import {reportNetworkProblem} from '../../lib/report-network-problem'
 import {UpdatesList} from './updates-list'
-import {ButtonCell} from '../components/cells/button'
 
 import type {TopLevelViewPropsType} from '../types'
 import type {UpdateType} from './types'
@@ -59,13 +58,6 @@ export class UpdatesContainer extends React.PureComponent<Props, State> {
 		this.setState(() => ({refreshing: false}))
 	}
 
-	onPress = () => {
-		this.props.navigation.push('CovidUpdatesView', {
-			updates: this.state.updates,
-			showAll: true,
-		})
-	}
-
 	render() {
 		if (this.state.error) {
 			return <NoticeView text={`Error: ${this.state.error.message}`} />
@@ -85,8 +77,6 @@ export class UpdatesContainer extends React.PureComponent<Props, State> {
 					showAll={false}
 					updates={this.state.updates}
 				/>
-
-				<ButtonCell onPress={this.onPress} title="See all updates…" />
 			</React.Fragment>
 		)
 	}

--- a/source/views/covid/updates-list.js
+++ b/source/views/covid/updates-list.js
@@ -37,7 +37,7 @@ export class UpdatesList extends React.PureComponent<Props> {
 		<UpdatesRow onPress={this.onPressUpdates} update={item} />
 	)
 
-	keyExtractor = (item: UpdateType) => item.id.toString()
+	keyExtractor = (item: UpdateType) => item.link
 
 	render() {
 		const showAll =

--- a/source/views/covid/updates-list.js
+++ b/source/views/covid/updates-list.js
@@ -1,0 +1,68 @@
+// @flow
+import * as React from 'react'
+import {StyleSheet, FlatList} from 'react-native'
+import * as c from '../components/colors'
+import {ListSeparator} from '../components/list'
+import {NoticeView} from '../components/notice'
+import {UpdatesRow} from './updates-row'
+import openUrl from '../components/open-url'
+
+import type {TopLevelViewPropsType} from '../types'
+import type {UpdateType} from './types'
+
+const styles = StyleSheet.create({
+	listContainer: {
+		backgroundColor: c.white,
+	},
+})
+
+type Props = TopLevelViewPropsType & {
+	name: string,
+	onRefresh: () => any,
+	updates: UpdateType[],
+	loading: boolean,
+	showAll: boolean,
+}
+
+export class UpdatesList extends React.PureComponent<Props> {
+	static navigationOptions = {
+		title: 'Updates on COVID-19',
+	}
+
+	onPressUpdates = (url: string) => {
+		return openUrl(url)
+	}
+
+	renderItem = ({item}: {item: UpdateType}) => (
+		<UpdatesRow onPress={this.onPressUpdates} update={item} />
+	)
+
+	keyExtractor = (item: UpdateType) => item.id.toString()
+
+	render() {
+		const showAll =
+			this.props.showAll !== undefined
+				? this.props.showAll
+				: this.props.navigation.state.params.showAll
+
+		const updates =
+			this.props.updates !== undefined
+				? this.props.updates
+				: this.props.navigation.state.params.updates
+
+		const data = showAll ? updates : updates.slice(0, 3)
+
+		return (
+			<FlatList
+				ItemSeparatorComponent={() => <ListSeparator />}
+				ListEmptyComponent={<NoticeView text="No updates." />}
+				data={data}
+				keyExtractor={this.keyExtractor}
+				onRefresh={this.props.onRefresh}
+				refreshing={this.props.loading}
+				renderItem={this.renderItem}
+				style={styles.listContainer}
+			/>
+		)
+	}
+}

--- a/source/views/covid/updates-list.js
+++ b/source/views/covid/updates-list.js
@@ -6,6 +6,7 @@ import {ListSeparator} from '../components/list'
 import {NoticeView} from '../components/notice'
 import {UpdatesRow} from './updates-row'
 import openUrl from '../components/open-url'
+import {ButtonCell} from '../components/cells/button'
 
 import type {TopLevelViewPropsType} from '../types'
 import type {UpdateType} from './types'
@@ -13,6 +14,9 @@ import type {UpdateType} from './types'
 const styles = StyleSheet.create({
 	listContainer: {
 		backgroundColor: c.white,
+	},
+	empty: {
+		padding: 20,
 	},
 })
 
@@ -29,12 +33,19 @@ export class UpdatesList extends React.PureComponent<Props> {
 		title: 'Updates on COVID-19',
 	}
 
-	onPressUpdates = (url: string) => {
+	onPressSeeAll = () => {
+		this.props.navigation.push('CovidUpdatesView', {
+			updates: this.props.updates,
+			showAll: true,
+		})
+	}
+
+	onPressUpdate = (url: string) => {
 		return openUrl(url)
 	}
 
 	renderItem = ({item}: {item: UpdateType}) => (
-		<UpdatesRow onPress={this.onPressUpdates} update={item} />
+		<UpdatesRow onPress={this.onPressUpdate} update={item} />
 	)
 
 	keyExtractor = (item: UpdateType) => item.link
@@ -52,10 +63,28 @@ export class UpdatesList extends React.PureComponent<Props> {
 
 		const data = showAll ? updates : updates.slice(0, 3)
 
+		const NoUpdatesView = () => (
+			<NoticeView style={styles.empty} text="No updates." />
+		)
+
+		const SeeMoreButton = () => {
+			// Hide this button if:
+			// * we have no data
+			// * we are on the full list of stories
+			if (data.length === 0 || showAll === true) {
+				return null
+			}
+
+			return (
+				<ButtonCell onPress={this.onPressSeeAll} title="See all updates…" />
+			)
+		}
+
 		return (
 			<FlatList
 				ItemSeparatorComponent={() => <ListSeparator />}
-				ListEmptyComponent={<NoticeView text="No updates." />}
+				ListEmptyComponent={<NoUpdatesView />}
+				ListFooterComponent={<SeeMoreButton />}
 				data={data}
 				keyExtractor={this.keyExtractor}
 				onRefresh={this.props.onRefresh}

--- a/source/views/covid/updates-row.js
+++ b/source/views/covid/updates-row.js
@@ -1,0 +1,41 @@
+// @flow
+
+import * as React from 'react'
+import moment from 'moment-timezone'
+import {Alert} from 'react-native'
+import {Column, Row} from '../components/layout'
+import {ListRow, Detail, Title} from '../components/list'
+import type {UpdateType} from './types'
+
+type Props = {
+	onPress: string => any,
+	update: UpdateType,
+}
+
+export class UpdatesRow extends React.PureComponent<Props> {
+	_onPress = () => {
+		if (!this.props.update.link) {
+			Alert.alert('There is nowhere to go for this update')
+			return
+		}
+		this.props.onPress(this.props.update.link)
+	}
+
+	render() {
+		const {update} = this.props
+
+		const posted = moment(update.date).format('MMM Do YYYY')
+		const description = update.title.rendered
+
+		return (
+			<ListRow arrowPosition="center" onPress={this._onPress}>
+				<Row alignItems="center">
+					<Column flex={1}>
+						<Title lines={2}>{posted}</Title>
+						<Detail lines={3}>{description}</Detail>
+					</Column>
+				</Row>
+			</ListRow>
+		)
+	}
+}

--- a/source/views/covid/updates-row.js
+++ b/source/views/covid/updates-row.js
@@ -23,7 +23,7 @@ export class UpdatesRow extends React.PureComponent<Props> {
 
 	render() {
 		const {update} = this.props
-		const posted = moment(update.date).format('MMM Do YYYY')
+		const posted = moment(update.datePublished).format('MMM Do YYYY')
 
 		return (
 			<ListRow arrowPosition="center" onPress={this._onPress}>

--- a/source/views/covid/updates-row.js
+++ b/source/views/covid/updates-row.js
@@ -23,16 +23,14 @@ export class UpdatesRow extends React.PureComponent<Props> {
 
 	render() {
 		const {update} = this.props
-
 		const posted = moment(update.date).format('MMM Do YYYY')
-		const description = update.title.rendered
 
 		return (
 			<ListRow arrowPosition="center" onPress={this._onPress}>
 				<Row alignItems="center">
 					<Column flex={1}>
 						<Title lines={2}>{posted}</Title>
-						<Detail lines={3}>{description}</Detail>
+						<Detail lines={3}>{update.title}</Detail>
 					</Column>
 				</Row>
 			</ListRow>

--- a/source/views/covid/updates-row.js
+++ b/source/views/covid/updates-row.js
@@ -12,6 +12,8 @@ type Props = {
 	update: UpdateType,
 }
 
+const TIMEZONE = 'America/Winnipeg'
+
 export class UpdatesRow extends React.PureComponent<Props> {
 	_onPress = () => {
 		if (!this.props.update.link) {
@@ -21,19 +23,32 @@ export class UpdatesRow extends React.PureComponent<Props> {
 		this.props.onPress(this.props.update.link)
 	}
 
+	calculateFromNow = (publishedOffset: moment) => {
+		const today = moment
+			.utc()
+			.tz(TIMEZONE)
+			.startOf('day')
+
+		if (today.isAfter(publishedOffset, 'day')) {
+			return moment.duration(publishedOffset - today).humanize(true)
+		}
+
+		return publishedOffset.fromNow()
+	}
+
 	render() {
 		const {update} = this.props
 
-		const posted = moment
-			.utc(update.datePublished)
-			.utcOffset(-6)
-			.format('MMM Do YYYY')
+		const publishedOffset = moment.utc(update.datePublished).tz(TIMEZONE)
+
+		const posted = publishedOffset.format('MMMM D, YYYY')
+		const fromNow = this.calculateFromNow(publishedOffset)
 
 		return (
 			<ListRow arrowPosition="center" onPress={this._onPress}>
 				<Row alignItems="center">
 					<Column flex={1}>
-						<Title lines={2}>{posted}</Title>
+						<Title lines={1}>{`${posted} (${fromNow})`}</Title>
 						<Detail lines={3}>{update.title}</Detail>
 					</Column>
 				</Row>

--- a/source/views/covid/updates-row.js
+++ b/source/views/covid/updates-row.js
@@ -23,7 +23,11 @@ export class UpdatesRow extends React.PureComponent<Props> {
 
 	render() {
 		const {update} = this.props
-		const posted = moment(update.datePublished).format('MMM Do YYYY')
+
+		const posted = moment
+			.utc(update.datePublished)
+			.utcOffset(-6)
+			.format('MMM Do YYYY')
 
 		return (
 			<ListRow arrowPosition="center" onPress={this._onPress}>

--- a/source/views/views.js
+++ b/source/views/views.js
@@ -192,6 +192,15 @@ export const allViews: ViewType[] = [
 		tint: c.lavender,
 		gradient: c.seafoamToGrass,
 	},
+	{
+		type: 'view',
+		view: 'CovidView',
+		title: 'Covid Response',
+		icon: 'bug',
+		foreground: 'light',
+		tint: c.red,
+		gradient: c.orangeToRed,
+	},
 ]
 
 export const allViewNames = allViews.map(v => v.view)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4252,13 +4252,18 @@ lodash.throttle@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
 
-lodash@4.17.9, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.16.4, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
+lodash@4.17.9, lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.9"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.9.tgz#9c056579af0bdbb4322e23c836df13ef2b271cb7"
 
 lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
+lodash@^4.16.4:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -5316,9 +5321,10 @@ react-native-search-bar@3.4.1:
   dependencies:
     prop-types "^15.5.10"
 
-"react-native-searchbar@https://github.com/MosesEsan/react-native-searchbar.git#setValue-function":
-  version "1.13.0"
-  resolved "https://github.com/MosesEsan/react-native-searchbar.git#9c9fd0ece3d5c5ba44697e8535021155ed696cc8"
+react-native-searchbar@1.16.0:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/react-native-searchbar/-/react-native-searchbar-1.16.0.tgz#839cafd55ba9ad56c5f4d25548750d41cb799a21"
+  integrity sha512-k+gn5m24yjyGP2EgsQvBgsxKV7aBDF6rFhA02Qh/ldJhCoKgnywXEdXrWLWljXs8xkH80ryMJtnfiw7rUlO4xg==
   dependencies:
     lodash "^4.16.4"
     react-native-vector-icons "^4.4.2"


### PR DESCRIPTION
By request, we're adding information about COVID-19 [from Carleton's website](https://www.carleton.edu/covid/).

- List of url resources
- News feed of campus updates 

Note: I basically copied the News views for the Updates container, list, and row with very little tweaks. Even though it looks like a ton of new logic, it's mostly our already battle-tested News component.

**Shipping checklist:**
- [x] Pull the docker image on CCC-Server so the new endpoint functions
- [x] Decide if this lives as a tile or a top-level notice
- [x] Fix the build (I think it's fixed in #335!)

**Testing steps:**

1. Stood up carleton-college on ccc-server
2. Set the `fetchData` url to `http://localhost:3000/v1/news/named/covid`
3. Took screenshots from those runs and attached to this PR

<details>
<summary>📸 Screenshots (slightly out of date WRT date formats)</summary>

~ | ~
--|--
![1](https://user-images.githubusercontent.com/5240843/94336055-edea0100-ff94-11ea-81b6-0f522f78c8d9.png) | ![3](https://user-images.githubusercontent.com/5240843/94336057-ef1b2e00-ff94-11ea-8e04-f3017e2dc1f0.png)
![android-1](https://user-images.githubusercontent.com/5240843/94336511-a1082980-ff98-11ea-9192-7fde6d84b488.png) | ![android-2](https://user-images.githubusercontent.com/5240843/94336512-a2395680-ff98-11ea-9fe8-925e0fa1a82e.png)

</details>

