### PR TITLE
Remove search bars to unbreak the build

### DIFF
--- a/source/views/components/searchbar/index.android.js
+++ b/source/views/components/searchbar/index.android.js
@@ -1,5 +1,6 @@
 // @flow
 
+/*
 import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import * as c from '../colors'
@@ -70,4 +71,9 @@ export class SearchBar extends React.PureComponent<Props, State> {
 			/>
 		)
 	}
+}
+*/
+
+export const SearchBar = () => {
+	return null
 }

--- a/source/views/components/searchbar/index.ios.js
+++ b/source/views/components/searchbar/index.ios.js
@@ -1,5 +1,6 @@
 // @flow
 
+/*
 import * as React from 'react'
 import {StyleSheet} from 'react-native'
 import NativeSearchBar from 'react-native-search-bar'
@@ -40,4 +41,9 @@ export const SearchBar = (props: PropsType) => {
 			textFieldBackgroundColor={props.textFieldBackgroundColor || c.white}
 		/>
 	)
+}
+*/
+
+export const SearchBar = () => {
+	return null
 }


### PR DESCRIPTION
In order to fix the search bars, this requires a lot of changes. Porting over the updated interfaces from AAO would involve an upgrade in both react and react native in part due to the adoption of hooks.

While this "fix" is a reduction in functionality across the the app (orgs, dictionary, map), it gets us building until we're ready to take on another big upgrade.