### PR TITLE
Athletics time based views with filters

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "semi": false
+}

--- a/app/modules/navigation-buttons/open-settings.tsx
+++ b/app/modules/navigation-buttons/open-settings.tsx
@@ -1,30 +1,30 @@
 import * as React from 'react'
-import {Touchable} from '../touchable'
+import { Touchable } from '../touchable'
 import * as c from '../colors'
-import {commonStyles, rightButtonStyles} from './styles'
-import {useRouter} from 'expo-router'
+import { commonStyles, rightButtonStyles } from './styles'
+import { useRouter } from 'expo-router'
 import Ionicon from '@expo/vector-icons/Ionicons'
 
 export function OpenSettingsButton(): React.JSX.Element {
-	const router = useRouter()
+  const router = useRouter()
 
-	return (
-		<Touchable
-			accessibilityLabel="Open Settings"
-			accessibilityRole="button"
-			accessible={true}
-			borderless={true}
-			highlight={false}
-			onPress={() => {
-				router.navigate('../settings')
-			}}
-			style={commonStyles.button}
-			testID="button-open-settings"
-		>
-			<Ionicon
-				name="cog"
-				style={[rightButtonStyles.icon, {color: c.label}]}
-			/>
-		</Touchable>
-	)
+  return (
+    <Touchable
+      accessibilityLabel="Open Settings"
+      accessibilityRole="button"
+      accessible={true}
+      borderless={true}
+      highlight={false}
+      onPress={() => {
+        router.navigate('../settings')
+      }}
+      style={commonStyles.button}
+      testID="button-open-settings"
+    >
+      <Ionicon
+        name="cog"
+        style={[rightButtonStyles.icon, { color: c.white }]}
+      />
+    </Touchable>
+  )
 }

--- a/app/views/athletics/EmptyListNotice.tsx
+++ b/app/views/athletics/EmptyListNotice.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { StyleSheet, View, Text } from 'react-native'
+import { NoticeView } from '../../modules/notice'
+import * as c from '../../modules/colors'
+import { DateSection } from './types'
+import { Constants } from './constants'
+import { useFilterStore } from './store'
+
+interface EmptyListNoticeProps {
+  selectedSection: DateSection
+  selectedFilters: string[]
+}
+
+export const EmptyListNotice = ({ selectedSection, selectedFilters }: EmptyListNoticeProps) => {
+  const { showChangeFiltersMessage } = useFilterStore()
+  
+  let message = ''
+  switch (selectedSection) {
+    case Constants.YESTERDAY:
+    case Constants.TODAY:
+      message = `No games ${selectedSection.toLowerCase()}`
+      break
+    case Constants.UPCOMING:
+      message = `No ${selectedSection.toLowerCase()} games`
+      break
+    default:
+      message = `No games`
+  }
+
+  if (showChangeFiltersMessage) {
+    message = `${message}. Try changing the filters?`
+  }
+
+  return (
+    <NoticeView
+      style={{ backgroundColor: c.transparent }}
+      text={message}
+    />
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: c.secondarySystemBackground,
+  },
+  text: {
+    color: c.label,
+    fontSize: 16,
+    textAlign: 'center',
+    marginHorizontal: 20,
+  },
+})

--- a/app/views/athletics/EmptyListNotice.tsx
+++ b/app/views/athletics/EmptyListNotice.tsx
@@ -4,16 +4,21 @@ import { NoticeView } from '../../modules/notice'
 import * as c from '../../modules/colors'
 import { DateSection } from './types'
 import { Constants } from './constants'
-import { useFilterStore } from './store'
+import { useFilterStore, selectShowChangeFiltersMessage } from './store'
 
 interface EmptyListNoticeProps {
   selectedSection: DateSection
   selectedFilters: string[]
 }
 
-export const EmptyListNotice = ({ selectedSection, selectedFilters }: EmptyListNoticeProps) => {
-  const { showChangeFiltersMessage } = useFilterStore()
-  
+export const EmptyListNotice = ({
+  selectedSection,
+  selectedFilters,
+}: EmptyListNoticeProps) => {
+  const showChangeFiltersMessage = useFilterStore(
+    selectShowChangeFiltersMessage,
+  )
+
   let message = ''
   switch (selectedSection) {
     case Constants.YESTERDAY:
@@ -32,10 +37,7 @@ export const EmptyListNotice = ({ selectedSection, selectedFilters }: EmptyListN
   }
 
   return (
-    <NoticeView
-      style={{ backgroundColor: c.transparent }}
-      text={message}
-    />
+    <NoticeView style={{ backgroundColor: c.transparent }} text={message} />
   )
 }
 

--- a/app/views/athletics/EmptyListNotice.tsx
+++ b/app/views/athletics/EmptyListNotice.tsx
@@ -24,10 +24,8 @@ export const EmptyListNotice = ({ selectedSection }: EmptyListNoticeProps) => {
     case Constants.UPCOMING:
       message = `No ${selectedSection.toLowerCase()} games`
       break
-    case Constants.FILTER:
-      return null
     default:
-      message = `No games`
+      return null
   }
 
   if (showChangeFiltersMessage) {

--- a/app/views/athletics/EmptyListNotice.tsx
+++ b/app/views/athletics/EmptyListNotice.tsx
@@ -8,13 +8,9 @@ import { useFilterStore, selectShowChangeFiltersMessage } from './store'
 
 interface EmptyListNoticeProps {
   selectedSection: DateSection
-  selectedFilters: string[]
 }
 
-export const EmptyListNotice = ({
-  selectedSection,
-  selectedFilters,
-}: EmptyListNoticeProps) => {
+export const EmptyListNotice = ({ selectedSection }: EmptyListNoticeProps) => {
   const showChangeFiltersMessage = useFilterStore(
     selectShowChangeFiltersMessage,
   )

--- a/app/views/athletics/EmptyListNotice.tsx
+++ b/app/views/athletics/EmptyListNotice.tsx
@@ -24,6 +24,8 @@ export const EmptyListNotice = ({ selectedSection }: EmptyListNoticeProps) => {
     case Constants.UPCOMING:
       message = `No ${selectedSection.toLowerCase()} games`
       break
+    case Constants.FILTER:
+      return null
     default:
       message = `No games`
   }

--- a/app/views/athletics/constants.ts
+++ b/app/views/athletics/constants.ts
@@ -4,4 +4,5 @@ export const Constants = {
   UPCOMING: 'Upcoming',
   FINALIZED: 'Finalized',
   ONGOING: 'Ongoing',
+  FILTER: 'Filter',
 }

--- a/app/views/athletics/constants.ts
+++ b/app/views/athletics/constants.ts
@@ -1,0 +1,7 @@
+export const Constants = {
+  YESTERDAY: 'Yesterday',
+  TODAY: 'Today',
+  UPCOMING: 'Upcoming',
+  FINALIZED: 'Finalized',
+  ONGOING: 'Ongoing',
+}

--- a/app/views/athletics/filters.tsx
+++ b/app/views/athletics/filters.tsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import {
+  SectionList,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native'
+
+import * as c from '../../modules/colors'
+import { useFilterStore } from './store'
+
+interface AthleticsFilterProps {
+  sports: { title: string; data: string[] }[]
+}
+
+export function AthleticsFilters({
+  sports,
+}: AthleticsFilterProps): React.JSX.Element {
+  const { selectedSports, toggleSport, setSelectedSports } = useFilterStore()
+
+  const handleSelectAll = (section: string) => {
+    const sectionSports = sports.find((s) => s.title === section)?.data || []
+    const allSelected = sectionSports.every((sport) =>
+      selectedSports.includes(sport),
+    )
+    if (allSelected) {
+      setSelectedSports(
+        selectedSports.filter((sport) => !sectionSports.includes(sport)),
+      )
+    } else {
+      setSelectedSports([...new Set([...selectedSports, ...sectionSports])])
+    }
+  }
+
+  return (
+    <SectionList
+      contentContainerStyle={styles.listContainer}
+      sections={sports}
+      keyExtractor={(item) => item}
+      renderItem={({ item }) => (
+        <TouchableOpacity
+          style={[
+            styles.filterButton,
+            selectedSports.includes(item) && styles.selectedFilterButton,
+          ]}
+          onPress={() => toggleSport(item)}
+        >
+          <Text
+            style={[
+              styles.filterButtonText,
+              selectedSports.includes(item) && styles.selectedFilterButtonText,
+            ]}
+          >
+            {item.replace(/^(Men's|Women's)\s/, '')}
+          </Text>
+        </TouchableOpacity>
+      )}
+      renderSectionHeader={({ section: { title } }) => (
+        <View>
+          <Text style={styles.sectionHeader}>{title}</Text>
+          <TouchableOpacity
+            style={[
+              styles.filterButton,
+              sports
+                .find((s) => s.title === title)
+                ?.data.every((sport) => selectedSports.includes(sport)) &&
+                styles.selectedFilterButton,
+            ]}
+            onPress={() => handleSelectAll(title)}
+          >
+            <Text
+              style={[
+                styles.filterButtonText,
+                sports
+                  .find((s) => s.title === title)
+                  ?.data.every((sport) => selectedSports.includes(sport)) &&
+                  styles.selectedFilterButtonText,
+              ]}
+            >
+              All
+            </Text>
+          </TouchableOpacity>
+        </View>
+      )}
+      stickyHeaderHiddenOnScroll={true}
+    />
+  )
+}
+
+const styles = StyleSheet.create({
+  listContainer: {
+    paddingHorizontal: 20,
+    backgroundColor: c.systemGroupedBackground,
+  },
+  sectionHeader: {
+    color: c.carletonBlue,
+    backgroundColor: c.systemGroupedBackground,
+    fontWeight: 'bold',
+    paddingTop: 15,
+  },
+  filterButton: {
+    backgroundColor: c.systemBackground,
+    borderRadius: 5,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    marginVertical: 5,
+    borderWidth: 1,
+    borderColor: c.separator,
+  },
+  filterButtonText: {
+    color: c.label,
+    fontSize: 14,
+  },
+  selectedFilterButton: {
+    backgroundColor: c.carletonBlue,
+    borderColor: c.carletonBlue,
+  },
+  selectedFilterButtonText: {
+    color: c.systemBackground,
+    fontWeight: 'bold',
+  },
+})

--- a/app/views/athletics/filters.tsx
+++ b/app/views/athletics/filters.tsx
@@ -36,6 +36,12 @@ export function AthleticsFilters({
   return (
     <SectionList
       contentContainerStyle={styles.listContainer}
+      ListFooterComponentStyle={styles.listFooter}
+      ListFooterComponent={
+        <Text style={styles.listFooterLabel}>
+          Filter preferences are saved locally to your device.
+        </Text>
+      }
       sections={sports}
       keyExtractor={(item) => item}
       renderItem={({ item }) => (
@@ -91,13 +97,20 @@ export function AthleticsFilters({
 const styles = StyleSheet.create({
   listContainer: {
     paddingHorizontal: 20,
+    height: '100%',
     backgroundColor: c.systemGroupedBackground,
   },
   sectionHeader: {
-    color: c.carletonBlue,
+    color: c.label,
     backgroundColor: c.systemGroupedBackground,
-    fontWeight: 'bold',
     paddingTop: 15,
+  },
+  listFooter: {
+    paddingTop: 15,
+  },
+  listFooterLabel: {
+    color: c.secondaryLabel,
+    fontSize: 12,
   },
   filterButton: {
     backgroundColor: c.systemBackground,
@@ -117,7 +130,7 @@ const styles = StyleSheet.create({
     borderColor: c.carletonBlue,
   },
   selectedFilterButtonText: {
-    color: c.systemBackground,
+    color: c.white,
     fontWeight: 'bold',
   },
 })

--- a/app/views/athletics/list.tsx
+++ b/app/views/athletics/list.tsx
@@ -1,17 +1,136 @@
-import React from "react";
-import { SectionList, StyleSheet, Text } from "react-native";
-import { useAthleticsGrouped } from "./query";
-import { AthleticsRow } from "./row";
-import { LoadingView, NoticeView } from "../../modules/notice";
+import React, { useCallback, useMemo } from 'react'
+import { SectionList, StyleSheet, View, Text } from 'react-native'
+import moment from 'moment-timezone'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+
+import { LoadingView, NoticeView } from '../../modules/notice'
+import * as c from '../../modules/colors'
+
+import { useAthleticsGrouped } from './query'
+import { AthleticsRow } from './row'
+import { TabBar } from './tabbar'
+import { DateSection, Score } from './types'
+import { Constants } from './constants'
+import { formatDateString } from './utils'
 
 export const AthleticsListView = () => {
+  const [selectedSection, setSelectedSection] = React.useState<DateSection>(
+    Constants.TODAY,
+  )
+
   const {
     data = [],
     error,
     refetch,
     isLoading,
     isError,
-  } = useAthleticsGrouped();
+  } = useAthleticsGrouped()
+
+  let insets = useSafeAreaInsets()
+
+  const currentSection = useMemo(() => {
+    switch (selectedSection) {
+      case Constants.UPCOMING:
+        const upcomingData = data
+          .filter(
+            (section) =>
+              ![Constants.YESTERDAY, Constants.TODAY].includes(section.title),
+          )
+          .flatMap((section) => section.data)
+        return { title: Constants.UPCOMING, data: upcomingData }
+      default:
+        return data.find((section) => section.title === selectedSection)
+    }
+  }, [selectedSection, data])
+
+  const renderSectionHeader = useCallback(
+    ({ section: { title } }: { section: { title: string } }) => {
+      switch (selectedSection) {
+        case Constants.YESTERDAY:
+          return null
+        default:
+          return <Text style={styles.sectionHeader}>{title}</Text>
+      }
+    },
+    [selectedSection],
+  )
+
+  const renderItem = useCallback(
+    ({ item }: { item: Score }) => (
+      <AthleticsRow
+        data={[item]}
+        includePrefix={selectedSection === Constants.UPCOMING}
+      />
+    ),
+    [selectedSection],
+  )
+
+  const renderSectionList = useCallback(
+    (sections: { title: string; data: Score[] }[]) => (
+      <SectionList
+        sections={sections}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        renderSectionHeader={renderSectionHeader}
+        contentContainerStyle={styles.sectionListContent}
+        contentInset={{ top: 0, bottom: insets.bottom }}
+      />
+    ),
+    [renderItem, renderSectionHeader],
+  )
+
+  const getSections = useCallback(() => {
+    if (selectedSection === Constants.UPCOMING) {
+      const upcomingSections = currentSection?.data.reduce(
+        (acc, score) => {
+          const date = moment(score.date_utc, 'M/D/YYYY h:mm:ss A')
+          const dateString = formatDateString(date)
+          if (!acc[dateString]) {
+            acc[dateString] = []
+          }
+          acc[dateString].push(score)
+          return acc
+        },
+        {} as Record<string, Score[]>,
+      )
+
+      return Object.keys(upcomingSections || {})
+        .map((date) => ({
+          title: date,
+          data: upcomingSections?.[date] || [],
+        }))
+        .filter((section) => (section.data ?? []).length)
+    }
+
+    if (selectedSection === Constants.YESTERDAY) {
+      const finalized = currentSection?.data.filter(
+        (score) => score.result !== '',
+      )
+      return finalized?.length ? [{ title: '', data: finalized }] : []
+    }
+
+    if (selectedSection === Constants.TODAY) {
+      const ongoing = currentSection?.data.filter(
+        (score) => score.status.indicator === 'O',
+      )
+      const finalized = currentSection?.data.filter(
+        (score) => score.status.indicator !== 'O' && score.result !== '',
+      )
+      const upcoming = currentSection?.data.filter(
+        (score) => score.status.indicator !== 'O' && score.result === '',
+      )
+
+      return [
+        { title: Constants.ONGOING, data: ongoing ?? [] },
+        { title: Constants.FINALIZED, data: finalized ?? [] },
+        { title: Constants.UPCOMING, data: upcoming ?? [] },
+      ].filter((section) => section.data.length)
+    }
+
+    return []
+  }, [selectedSection, currentSection])
+
+  const sections = useMemo(() => getSections(), [getSections])
 
   if (isError) {
     return (
@@ -20,34 +139,40 @@ export const AthleticsListView = () => {
         onPress={refetch}
         text={`A problem occurred while loading: ${String(error)}`}
       />
-    );
+    )
   }
 
   if (isLoading) {
-    return <LoadingView />;
+    return <LoadingView />
   }
 
   if (!data.length) {
-    return <NoticeView text="Oops! We didn't find any data." />;
+    return <NoticeView text="Oops! We didn＇t find any data." />
   }
 
   return (
-    <SectionList
-      sections={data}
-      keyExtractor={(item) => item.id}
-      renderItem={({ item }) => <AthleticsRow data={[item]} />}
-      renderSectionHeader={({ section }) => (
-        <Text style={styles.header}>{section.title}</Text>
-      )}
-    />
-  );
-};
+    <View style={styles.container}>
+      <TabBar
+        selectedSection={selectedSection}
+        onSelectSection={setSelectedSection}
+      />
+      {renderSectionList(sections)}
+    </View>
+  )
+}
 
 const styles = StyleSheet.create({
-  header: {
-    fontSize: 16,
-    fontWeight: "bold",
-    backgroundColor: "#f0f0f0",
+  container: {
+    flex: 1,
+    backgroundColor: c.secondarySystemBackground,
+  },
+  sectionListContent: {
     padding: 10,
   },
-});
+  sectionHeader: {
+    backgroundColor: c.secondarySystemBackground,
+    color: c.label,
+    padding: 5,
+    paddingHorizontal: 10,
+  },
+})

--- a/app/views/athletics/list.tsx
+++ b/app/views/athletics/list.tsx
@@ -107,12 +107,12 @@ export const AthleticsListView = () => {
         {} as Record<string, Score[]>,
       )
 
-      return Object.keys(upcomingSections || {})
-        .map((date) => ({
+      return Object.entries(upcomingSections || {})
+        .map(([date, scores]) => ({
           title: date,
-          data: upcomingSections?.[date] || [],
+          data: scores,
         }))
-        .filter((section) => (section.data ?? []).length)
+        .filter((section) => section.data.length)
     }
 
     if (selectedSection === Constants.YESTERDAY) {

--- a/app/views/athletics/list.tsx
+++ b/app/views/athletics/list.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { SectionList, StyleSheet, View, Text, TouchableOpacity, Modal, SectionListData } from 'react-native'
+import { SectionList, StyleSheet, View, Text } from 'react-native'
 import moment from 'moment-timezone'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
@@ -36,7 +36,7 @@ export const AthleticsListView = () => {
     const allSports = data.flatMap((section) =>
       section.data.map((score) => score.sport),
     )
-    const uniqueSports = [...new Set(allSports)].sort()  
+    const uniqueSports = [...new Set(allSports)].sort()
     setTotalSports(uniqueSports.length)
 
     const menSports = uniqueSports.filter((sport) => sport.includes("Men's"))
@@ -178,7 +178,9 @@ export const AthleticsListView = () => {
 
       <SectionList
         sections={sections}
-        ListEmptyComponent={<EmptyListNotice selectedSection={selectedSection} selectedFilters={selectedSports} />}
+        ListEmptyComponent={
+          <EmptyListNotice selectedSection={selectedSection} />
+        }
         keyExtractor={(item) => item.id}
         renderItem={renderItem}
         renderSectionHeader={renderSectionHeader}

--- a/app/views/athletics/list.tsx
+++ b/app/views/athletics/list.tsx
@@ -1,5 +1,5 @@
-import React, { useCallback, useMemo, useState, useEffect } from 'react'
-import { SectionList, StyleSheet, View, Text } from 'react-native'
+import React, { useCallback, useMemo, useState } from 'react'
+import { SectionList, StyleSheet, View, Text, TouchableOpacity, Modal, SectionListData } from 'react-native'
 import moment from 'moment-timezone'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
@@ -14,12 +14,13 @@ import { Constants } from './constants'
 import { formatDateString } from './utils'
 import { AthleticsFilters } from './filters'
 import { useFilterStore } from './store'
+import { EmptyListNotice } from './EmptyListNotice'
 
 export const AthleticsListView = () => {
   const [selectedSection, setSelectedSection] = useState<DateSection>(
     Constants.TODAY,
   )
-  const { selectedSports } = useFilterStore()
+  const { selectedSports, setTotalSports } = useFilterStore()
 
   const {
     data = [],
@@ -35,7 +36,9 @@ export const AthleticsListView = () => {
     const allSports = data.flatMap((section) =>
       section.data.map((score) => score.sport),
     )
-    const uniqueSports = [...new Set(allSports)].sort()
+    const uniqueSports = [...new Set(allSports)].sort()  
+    setTotalSports(uniqueSports.length)
+
     const menSports = uniqueSports.filter((sport) => sport.includes("Men's"))
     const womenSports = uniqueSports.filter((sport) =>
       sport.includes("Women's"),
@@ -175,19 +178,7 @@ export const AthleticsListView = () => {
 
       <SectionList
         sections={sections}
-        ListEmptyComponent={() =>
-          selectedSection !== Constants.FILTER && (
-            <NoticeView
-              style={{ backgroundColor: c.transparent }}
-              text={
-                selectedSection === Constants.YESTERDAY ||
-                selectedSection === Constants.TODAY
-                  ? `No games ${selectedSection.toLowerCase()}. Try changing the filters?`
-                  : `No ${selectedSection.toLowerCase()} games. Try changing the filters?`
-              }
-            />
-          )
-        }
+        ListEmptyComponent={<EmptyListNotice selectedSection={selectedSection} selectedFilters={selectedSports} />}
         keyExtractor={(item) => item.id}
         renderItem={renderItem}
         renderSectionHeader={renderSectionHeader}

--- a/app/views/athletics/list.tsx
+++ b/app/views/athletics/list.tsx
@@ -179,7 +179,12 @@ export const AthleticsListView = () => {
           selectedSection !== Constants.FILTER && (
             <NoticeView
               style={{ backgroundColor: c.transparent }}
-              text={`No games available. Try changing the filters?`}
+              text={
+                selectedSection === Constants.YESTERDAY ||
+                selectedSection === Constants.TODAY
+                  ? `No games ${selectedSection.toLowerCase()}. Try changing the filters?`
+                  : `No ${selectedSection.toLowerCase()} games. Try changing the filters?`
+              }
             />
           )
         }

--- a/app/views/athletics/query.ts
+++ b/app/views/athletics/query.ts
@@ -1,14 +1,15 @@
-import { client } from "../../modules/api";
-import { useQuery, UseQueryResult } from "@tanstack/react-query";
-import { groupBy, toPairs } from "lodash";
-import { AthleticsResponse, AthleticsData, GroupedScores } from "./types";
+import { client } from '../../modules/api'
+import { useQuery, UseQueryResult } from '@tanstack/react-query'
+import { groupBy, toPairs } from 'lodash'
+import { AthleticsResponse, AthleticsData, GroupedScores } from './types'
+import { groupScoresByDate } from './utils'
 
 export const keys = {
-  all: ["games"] as const,
-};
+  all: ['games'] as const,
+}
 
 let athleticsUrl =
-  "http://athletics.carleton.edu/services/scores_chris.aspx?format=json";
+  'http://athletics.carleton.edu/services/scores_chris.aspx?format=json'
 
 export function useAthleticsGrouped(): UseQueryResult<GroupedScores[]> {
   return useQuery({
@@ -17,51 +18,9 @@ export function useAthleticsGrouped(): UseQueryResult<GroupedScores[]> {
       // TODO: move this to the proxy server (which is why we have an undefined prefixUrl)
       let response = await client
         .get(athleticsUrl, { signal, prefixUrl: undefined })
-        .json();
-      return (response as { scores: AthleticsResponse[] }).scores;
+        .json()
+      return (response as { scores: AthleticsResponse[] }).scores
     },
-    select: (scores) => {
-      const now = Date.now();
-      const startOfToday = new Date().setHours(0, 0, 0, 0) / 1000;
-      const endOfToday = new Date().setHours(23, 59, 59, 999) / 1000;
-
-      // split into categories
-      const todayGames = scores.filter(
-        (game) =>
-          game.timestamp >= startOfToday && game.timestamp <= endOfToday,
-      );
-      const upcomingGames = scores.filter(
-        (game) => game.timestamp > endOfToday,
-      );
-      const pastGames = scores.filter((game) => game.timestamp < startOfToday);
-
-      // sort each category
-      const sortByTimeAndSport = (
-        a: AthleticsResponse,
-        b: AthleticsResponse,
-      ) => {
-        if (a.timestamp === b.timestamp) {
-          return a.sport.localeCompare(b.sport);
-        }
-        return a.timestamp - b.timestamp;
-      };
-
-      const sortedToday = todayGames.sort(sortByTimeAndSport);
-      const sortedUpcoming = upcomingGames.sort(sortByTimeAndSport);
-      const sortedPast = pastGames.sort((a, b) => sortByTimeAndSport(b, a)); // Reverse for past games
-
-      // combine all sorted games
-      const sortedScores = [...sortedToday, ...sortedUpcoming, ...sortedPast];
-
-      // group by sport
-      const grouped = groupBy(sortedScores, "sport");
-
-      return toPairs(grouped)
-        .sort(([titleA], [titleB]) => titleA.localeCompare(titleB))
-        .map(([title, data]) => ({
-          title,
-          data,
-        }));
-    },
-  });
+    select: groupScoresByDate,
+  })
 }

--- a/app/views/athletics/row.tsx
+++ b/app/views/athletics/row.tsx
@@ -28,6 +28,7 @@ export function AthleticsRow({
 
         return (
           <View key={`${index}-${item.id}`} style={styles.rowContainer}>
+            <Text style={styles.sportName}>{item.sport}</Text>
             <View style={styles.container}>
               <View style={styles.teamLeft}>
                 {item.hometeam_logo ? (
@@ -90,6 +91,13 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.1,
     shadowRadius: 5,
     elevation: 3,
+  },
+  sportName: {
+    color: c.label,
+    fontSize: 11,
+    fontWeight: 'bold',
+    padding: 2,
+    textAlign: 'center',
   },
   container: {
     backgroundColor: c.systemBackground,

--- a/app/views/athletics/row.tsx
+++ b/app/views/athletics/row.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from 'react'
 import {
   StyleSheet,
   ScrollView,
@@ -6,144 +6,160 @@ import {
   Text,
   Image,
   PixelRatio,
-} from "react-native";
+} from 'react-native'
 
-import { AthleticsData } from "./types";
-import { formatGameTime } from "./utils";
+import { AthleticsData } from './types'
 
-import * as c from "../../modules/colors";
+import * as c from '../../modules/colors'
 
-export function AthleticsRow({ data }: { data: AthleticsData }) {
+export function AthleticsRow({
+  data,
+  includePrefix = true,
+}: {
+  data: AthleticsData
+  includePrefix?: boolean
+}) {
   return (
     <ScrollView>
-      {data.map((item, index) => (
-        <View key={`${index}-${item.id}`}>
-          <Text style={styles.sportTime}>{formatGameTime(item.date_utc)}</Text>
-          <View style={styles.container}>
-            <View style={styles.team}>
-              {item.hometeam_logo ? (
-                <Image
-                  style={styles.teamLogo}
-                  source={{ uri: item.hometeam_logo }}
-                />
-              ) : null}
+      {data.map((item, index) => {
+        if (item.prescore_info === 'No team scores') {
+          return null
+        }
 
-              <Text style={styles.teamName}>
-                {item.hometeam.trim().toUpperCase()}
-              </Text>
-            </View>
+        return (
+          <View key={`${index}-${item.id}`} style={styles.rowContainer}>
+            <View style={styles.container}>
+              <View style={styles.teamLeft}>
+                {item.hometeam_logo ? (
+                  <Image
+                    style={styles.teamLogo}
+                    source={{ uri: item.hometeam_logo }}
+                  />
+                ) : null}
 
-            <View style={styles.gameInfo}>
-              <Text style={styles.infoProcess}>
-                {item.prescore_info
-                  ? item.prescore_info
-                  : item.status.indicator}
-              </Text>
+                <Text style={styles.teamName}>{item.hometeam.trim()}</Text>
+              </View>
 
-              {item.status.indicator !== "A" && (
-                <View style={styles.infoScorePanel}>
-                  <Text style={styles.infoScore}>{item.team_score}</Text>
-                  <View style={styles.infoDivider} />
-                  <Text style={styles.infoScore}>{item.opponent_score}</Text>
-                </View>
-              )}
-            </View>
+              <View style={styles.gameInfo}>
+                {item.status.indicator === 'A' ? (
+                  <Text style={styles.infoTime}>{item.time}</Text>
+                ) : (
+                  <>
+                    <Text style={styles.infoProcess} />
 
-            <View style={styles.team}>
-              {item.opponent_logo ? (
-                <Image
-                  style={styles.teamLogo}
-                  source={{ uri: item.opponent_logo }}
-                />
-              ) : null}
+                    {item.status.indicator === 'O' && (
+                      <View style={styles.infoScorePanel}>
+                        <Text style={styles.infoScore}>{item.team_score}</Text>
+                        <View style={styles.infoDivider} />
+                        <Text style={styles.infoScore}>
+                          {item.opponent_score}
+                        </Text>
+                      </View>
+                    )}
+                  </>
+                )}
+              </View>
 
-              <Text style={styles.teamName}>
-                {item.opponent.trim().toUpperCase()}
-              </Text>
+              <View style={styles.teamRight}>
+                {item.opponent_logo ? (
+                  <Image
+                    style={styles.teamLogo}
+                    source={{ uri: item.opponent_logo }}
+                  />
+                ) : null}
+
+                <Text style={styles.teamName}>{item.opponent.trim()}</Text>
+              </View>
             </View>
           </View>
-        </View>
-      ))}
+        )
+      })}
     </ScrollView>
-  );
+  )
 }
 
 const styles = StyleSheet.create({
+  rowContainer: {
+    backgroundColor: c.systemBackground,
+    borderRadius: 10,
+    marginHorizontal: 3,
+    marginVertical: 5,
+    padding: 3,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 5,
+    elevation: 3,
+  },
   container: {
-    backgroundColor: c.white,
+    backgroundColor: c.systemBackground,
     borderRadius: 5,
     flex: 1,
-    flexDirection: "row",
-    marginHorizontal: 12,
-    marginBottom: 10,
+    padding: 5,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
   },
   sportTime: {
     color: c.black,
-    fontWeight: "500",
-    fontSize: 16,
-    padding: 5,
-    textAlign: "center",
+    fontWeight: '500',
+    fontSize: 14,
+    padding: 4,
+    textAlign: 'center',
   },
-  team: {
-    alignItems: "center",
-    borderRadius: 5,
-    flex: 1.5,
+  teamLeft: {
+    alignItems: 'center',
+    flex: 1,
+  },
+  teamRight: {
+    alignItems: 'center',
+    flex: 1,
   },
   teamLogo: {
-    width: 50,
-    height: 50,
-    marginTop: 12,
-    marginBottom: 5,
-  },
-  teamCity: {
-    color: c.black,
-    fontSize: 11,
-    marginTop: 2,
+    width: 30,
+    height: 30,
+    marginVertical: 4,
   },
   teamName: {
-    color: c.black,
-    fontWeight: "bold",
-    fontSize: 13,
-    position: "relative",
-    paddingBottom: 12,
-    top: 0,
-    justifyContent: "center",
-    textAlign: "center",
+    color: c.label,
+    fontSize: 12,
+    textAlign: 'center',
   },
   gameInfo: {
-    alignItems: "center",
-    flex: 1.5,
-    flexDirection: "column",
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: 1,
   },
   infoProcess: {
-    color: c.black,
-    fontSize: 10,
-    marginTop: 22,
-    marginBottom: 3,
+    fontSize: 8,
+    marginVertical: 2,
+  },
+  infoTime: {
+    color: c.label,
+    fontSize: 14,
+    textAlignVertical: 'center',
+    textAlign: 'center',
   },
   processUnstart: {
-    fontSize: 22,
-    position: "relative",
-    top: 13,
+    fontSize: 18,
   },
   infoScorePanel: {
-    flex: 1,
-    flexDirection: "row",
-    justifyContent: "center",
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: '100%',
   },
   infoScore: {
-    color: c.black,
-    fontWeight: "500",
-    fontSize: 24,
-    textAlign: "center",
-    width: 50,
+    color: c.label,
+    fontWeight: '500',
+    fontSize: 20,
+    textAlign: 'center',
+    width: 40,
   },
   infoDivider: {
     backgroundColor: c.systemGray,
-    height: 25,
-    marginTop: 7,
-    marginLeft: 10,
-    marginRight: 10,
+    height: 20,
     width: 2 / PixelRatio.get(),
+    marginHorizontal: 8,
   },
-});
+})

--- a/app/views/athletics/store.ts
+++ b/app/views/athletics/store.ts
@@ -8,7 +8,6 @@ interface FilterState {
   setSelectedSports: (sports: string[]) => void
   setTotalSports: (count: number) => void
   toggleSport: (sport: string) => void
-  showChangeFiltersMessage: boolean
 }
 
 export const useFilterStore = create(
@@ -28,12 +27,6 @@ export const useFilterStore = create(
             : [...state.selectedSports, sport]
           return { selectedSports: updatedSports }
         }),
-      get showChangeFiltersMessage() {
-        const filtersWithoutAll = get().selectedSports.filter(filter => filter !== 'All')
-        const noFiltersSelected = filtersWithoutAll.length === 0
-        const allFiltersSelected = filtersWithoutAll.length === get().totalSports
-        return noFiltersSelected || (filtersWithoutAll.length > 0 && !allFiltersSelected)
-      },
     }),
     {
       name: 'athletics',
@@ -41,3 +34,14 @@ export const useFilterStore = create(
     },
   ),
 )
+
+export const selectShowChangeFiltersMessage = (state: FilterState) => {
+  const filtersWithoutAll = state.selectedSports.filter(
+    (filter) => filter !== 'All',
+  )
+  const noFiltersSelected = filtersWithoutAll.length === 0
+  const allFiltersSelected = filtersWithoutAll.length === state.totalSports
+  return (
+    noFiltersSelected || (filtersWithoutAll.length > 0 && !allFiltersSelected)
+  )
+}

--- a/app/views/athletics/store.ts
+++ b/app/views/athletics/store.ts
@@ -4,15 +4,20 @@ import AsyncStorage from '@react-native-async-storage/async-storage'
 
 interface FilterState {
   selectedSports: string[]
+  totalSports: number
   setSelectedSports: (sports: string[]) => void
+  setTotalSports: (count: number) => void
   toggleSport: (sport: string) => void
+  showChangeFiltersMessage: boolean
 }
 
 export const useFilterStore = create(
   persist<FilterState>(
-    (set) => ({
+    (set, get) => ({
       selectedSports: ['All'],
+      totalSports: 0,
       setSelectedSports: (sports) => set({ selectedSports: sports }),
+      setTotalSports: (count) => set({ totalSports: count }),
       toggleSport: (sport) =>
         set((state) => {
           const isSelected = state.selectedSports.includes(sport)
@@ -23,6 +28,12 @@ export const useFilterStore = create(
             : [...state.selectedSports, sport]
           return { selectedSports: updatedSports }
         }),
+      get showChangeFiltersMessage() {
+        const filtersWithoutAll = get().selectedSports.filter(filter => filter !== 'All')
+        const noFiltersSelected = filtersWithoutAll.length === 0
+        const allFiltersSelected = filtersWithoutAll.length === get().totalSports
+        return noFiltersSelected || (filtersWithoutAll.length > 0 && !allFiltersSelected)
+      },
     }),
     {
       name: 'athletics',

--- a/app/views/athletics/store.ts
+++ b/app/views/athletics/store.ts
@@ -1,0 +1,32 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import AsyncStorage from '@react-native-async-storage/async-storage'
+
+interface FilterState {
+  selectedSports: string[]
+  setSelectedSports: (sports: string[]) => void
+  toggleSport: (sport: string) => void
+}
+
+export const useFilterStore = create(
+  persist<FilterState>(
+    (set) => ({
+      selectedSports: ['All'],
+      setSelectedSports: (sports) => set({ selectedSports: sports }),
+      toggleSport: (sport) =>
+        set((state) => {
+          const isSelected = state.selectedSports.includes(sport)
+          const updatedSports = isSelected
+            ? state.selectedSports.filter(
+                (selectedSport) => selectedSport !== sport,
+              )
+            : [...state.selectedSports, sport]
+          return { selectedSports: updatedSports }
+        }),
+    }),
+    {
+      name: 'athletics',
+      storage: createJSONStorage(() => AsyncStorage),
+    },
+  ),
+)

--- a/app/views/athletics/tabbar.tsx
+++ b/app/views/athletics/tabbar.tsx
@@ -1,0 +1,77 @@
+import React from 'react'
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import { DateSection } from './types'
+import { Constants } from './constants'
+import * as c from '../../modules/colors'
+
+interface TabBarProps {
+  selectedSection: DateSection
+  onSelectSection: (section: DateSection) => void
+}
+
+export function TabBar({
+  selectedSection,
+  onSelectSection,
+}: TabBarProps): React.JSX.Element {
+  const sections: DateSection[] = [
+    Constants.YESTERDAY,
+    Constants.TODAY,
+    Constants.UPCOMING,
+  ]
+
+  const handlePress = (section: DateSection) => {
+    if (section !== selectedSection) {
+      onSelectSection(section)
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      {sections.map((section) => (
+        <TouchableOpacity
+          key={section}
+          style={[
+            styles.tab,
+            selectedSection === section && styles.selectedTab,
+          ]}
+          onPress={() => handlePress(section)}
+        >
+          <Text
+            style={[
+              styles.tabText,
+              selectedSection === section && styles.selectedTabText,
+            ]}
+          >
+            {section}
+          </Text>
+        </TouchableOpacity>
+      ))}
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    backgroundColor: c.systemBackground,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: c.separator,
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: 12,
+    alignItems: 'center',
+  },
+  selectedTab: {
+    borderBottomWidth: 2,
+    borderBottomColor: c.carletonBlue,
+  },
+  tabText: {
+    fontSize: 14,
+    color: c.label,
+  },
+  selectedTabText: {
+    fontWeight: 'bold',
+    color: c.carletonBlue,
+  },
+})

--- a/app/views/athletics/tabbar.tsx
+++ b/app/views/athletics/tabbar.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
+import React, { useEffect, useRef } from 'react'
+import { StyleSheet, Text, TouchableOpacity, View, Animated, Dimensions } from 'react-native'
 import { DateSection } from './types'
 import { Constants } from './constants'
 import * as c from '../../modules/colors'
@@ -26,15 +26,28 @@ export function TabBar({
     }
   }
 
+  const animatedValue = useRef(new Animated.Value(0)).current
+
+  useEffect(() => {
+    const index = sections.indexOf(selectedSection)
+    Animated.spring(animatedValue, {
+      toValue: index,
+      useNativeDriver: false,
+    }).start()
+  }, [selectedSection])
+
+  const tabWidth = Dimensions.get('window').width / sections.length
+  const translateX = animatedValue.interpolate({
+    inputRange: [0, sections.length - 1],
+    outputRange: [0, tabWidth * (sections.length - 1)],
+  })
+
   return (
     <View style={styles.container}>
       {sections.map((section) => (
         <TouchableOpacity
           key={section}
-          style={[
-            styles.tab,
-            selectedSection === section && styles.selectedTab,
-          ]}
+          style={styles.tab}
           onPress={() => handlePress(section)}
         >
           <Text
@@ -48,6 +61,12 @@ export function TabBar({
           </Text>
         </TouchableOpacity>
       ))}
+      <Animated.View
+        style={[
+          styles.animatedTabIndicator,
+          { width: tabWidth, transform: [{ translateX }] },
+        ]}
+      />
     </View>
   )
 }
@@ -58,6 +77,7 @@ const styles = StyleSheet.create({
     backgroundColor: c.systemBackground,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: c.separator,
+    position: 'relative',
   },
   tab: {
     flex: 1,
@@ -75,5 +95,11 @@ const styles = StyleSheet.create({
   selectedTabText: {
     fontWeight: 'bold',
     color: c.carletonBlue,
+  },
+  animatedTabIndicator: {
+    position: 'absolute',
+    bottom: 0,
+    height: 2,
+    backgroundColor: c.carletonBlue,
   },
 })

--- a/app/views/athletics/tabbar.tsx
+++ b/app/views/athletics/tabbar.tsx
@@ -5,21 +5,22 @@ import { Constants } from './constants'
 import * as c from '../../modules/colors'
 
 interface TabBarProps {
-  selectedSection: DateSection
-  onSelectSection: (section: DateSection) => void
+  selectedSection: DateSection | 'Filter'
+  onSelectSection: (section: DateSection | 'Filter') => void
 }
 
 export function TabBar({
   selectedSection,
   onSelectSection,
 }: TabBarProps): React.JSX.Element {
-  const sections: DateSection[] = [
+  const sections: (DateSection | 'Filter')[] = [
     Constants.YESTERDAY,
     Constants.TODAY,
     Constants.UPCOMING,
+    Constants.FILTER,
   ]
 
-  const handlePress = (section: DateSection) => {
+  const handlePress = (section: DateSection | 'Filter') => {
     if (section !== selectedSection) {
       onSelectSection(section)
     }
@@ -37,6 +38,7 @@ export function TabBar({
           onPress={() => handlePress(section)}
         >
           <Text
+            numberOfLines={1}
             style={[
               styles.tabText,
               selectedSection === section && styles.selectedTabText,

--- a/app/views/athletics/types.ts
+++ b/app/views/athletics/types.ts
@@ -1,67 +1,79 @@
+import { Constants } from './constants'
+
 export interface LocationInfo {
-  location: string;
-  HAN: "H" | "A" | "N";
-  facility: string;
+  location: string
+  HAN: 'H' | 'A' | 'N'
+  facility: string
 }
 
 export interface StatusInfo {
-  indicator: "O" | "A";
-  value: string;
+  indicator: 'O' | 'A'
+  value: string
 }
 
 export interface Link {
-  url: string;
-  text: string;
+  url: string
+  text: string
 }
 
 export interface Coverage {
-  [key: string]: unknown;
+  [key: string]: unknown
 }
 
 export interface Links {
-  postgame?: Link;
-  boxscore?: Link;
-  livestats?: Link;
-  streaming_video?: Link;
+  postgame?: Link
+  boxscore?: Link
+  livestats?: Link
+  streaming_video?: Link
 }
 
-export type GameResult = "W" | "L" | "N" | "";
+export type GameResult = 'W' | 'L' | 'N' | ''
 
 export interface Score {
-  id: string;
-  sport: string;
-  sport_abbrev: string;
-  date: string;
-  dateFormatted: string;
-  date_utc: string;
-  date_end_utc: string;
-  time: string;
-  timestamp: number;
-  location: LocationInfo;
-  status: StatusInfo;
-  hometeam: string;
-  hometeam_logo: string;
-  opponent: string;
-  opponent_logo: string;
-  team_score: string;
-  opponent_score: string;
-  result: GameResult;
-  ip_time: string;
-  prescore_info: string;
-  postscore_info: string;
-  links: Links;
-  coverage: Coverage;
+  id: string
+  sport: string
+  sport_abbrev: string
+  date: string
+  dateFormatted: string
+  date_utc: string
+  date_end_utc: string
+  time: string
+  timestamp: number
+  location: LocationInfo
+  status: StatusInfo
+  hometeam: string
+  hometeam_logo: string
+  opponent: string
+  opponent_logo: string
+  team_score: string
+  opponent_score: string
+  result: GameResult
+  ip_time: string
+  prescore_info: string
+  postscore_info: string
+  links: Links
+  coverage: Coverage
 }
 
 export interface AthleticsResponse {
-  timestamp: any;
-  status: any;
-  scores: Score[];
+  timestamp: any
+  status: any
+  scores: Score[]
 }
 
-export type AthleticsData = Score[];
+export type AthleticsData = Score[]
 
 export interface GroupedScores {
-  title: string;
-  data: Score[];
+  title: string
+  data: Score[]
+}
+
+export type DateSection =
+  | typeof Constants.YESTERDAY
+  | typeof Constants.TODAY
+  | typeof Constants.UPCOMING
+
+export interface DateGroupedScores {
+  title: DateSection
+  data: Score[]
 }

--- a/app/views/athletics/utils.ts
+++ b/app/views/athletics/utils.ts
@@ -40,9 +40,9 @@ export const groupScoresByDate = (scores: Score[]): DateGroupedScores[] => {
     }
   })
 
-  const upcomingSections = Object.keys(upcoming).map((date) => ({
-    title: date as DateSection,
-    data: upcoming[date],
+  const upcomingSections = Object.entries(upcoming).map(([date, scores]) => ({
+    title: date,
+    data: scores,
   }))
 
   return [

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,8 @@
         "react-native-typography": "^1.4.1",
         "react-native-web": "~0.19.13",
         "react-native-webview": "13.12.5",
-        "tinycolor2": "^1.6.0"
+        "tinycolor2": "^1.6.0",
+        "zustand": "^5.0.3"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -17383,6 +17384,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "react-native-typography": "^1.4.1",
     "react-native-web": "~0.19.13",
     "react-native-webview": "13.12.5",
-    "tinycolor2": "^1.6.0"
+    "tinycolor2": "^1.6.0",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
* adds zustand for lightweight effective persistence of the athletic filters
* adds a top-tabs component to athletics to filter by date (yesterday, today, upcoming)
* adds filters to the tabs for selecting specific categories
* persists the categories across restarts with AsyncStorage
* color tweaks to better fit light and dark schemes

Notes:
- Carleton and St. Olaf both use these the same athletics provider so this could be taken into AAO if this works well
- The data for upcoming events extends to whatever the api returns. Default is showing events for the next 6 days. Maybe it accepts parameters?

![athletics](https://github.com/user-attachments/assets/2c51e70e-ff1e-4bc2-8316-2dcb0a7c5ea8)
